### PR TITLE
fix: request ACCESS_FINE_LOCATION as required by Android NavSDK

### DIFF
--- a/SampleApp/src/app.tsx
+++ b/SampleApp/src/app.tsx
@@ -83,7 +83,7 @@ const App: React.FC = (): ReactElement => {
   const checkPermissions = async () => {
     const result = await request(
       Platform.OS == 'android'
-        ? PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION
+        ? PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION
         : PERMISSIONS.IOS.LOCATION_ALWAYS,
     );
 


### PR DESCRIPTION
Fixes #12

The native SDK requires ACCESS_FINE_LOCATION to be granted and it is enforced.