### PR TITLE
fix: address crash on single destination navigation due to invalid waypoint

### DIFF
--- a/components/navigation/navigationView/navigationViewController.ts
+++ b/components/navigation/navigationView/navigationViewController.ts
@@ -33,13 +33,13 @@ export const getNavigationViewController = (
   return {
     setDestination: (waypoint: Waypoint, routingOptions?: RoutingOptions) => {
       let args: object[] = [];
-      args.push(waypoint);
+      args.push([waypoint]);
 
       if (routingOptions != null) {
         args.push(routingOptions);
       }
 
-      sendCommand(viewId, commands.setDestination, args);
+      sendCommand(viewId, commands.setDestinations, args);
     },
     setDestinations: (
       waypoints: Waypoint[],

--- a/ios/react-native-navigation-sdk/NavViewController.m
+++ b/ios/react-native-navigation-sdk/NavViewController.m
@@ -201,24 +201,28 @@ NSDictionary *_tosParams = nil;
   destinations = [[NSMutableArray alloc] init];
 
   for (NSDictionary *wp in waypoints) {
-    NSString *placeId = @"";
     GMSNavigationMutableWaypoint *w;
 
-    placeId = wp[@"placeId"];
+    NSString *placeId = wp[@"placeId"];
 
-    if ([placeId isEqual:@""] && wp[@"position"] != nil) {
+    if (placeId && ![placeId isEqual:@""]) {
+      w = [[GMSNavigationMutableWaypoint alloc] initWithPlaceID:placeId title:wp[@"title"]];     
+    } else if (wp[@"position"]) {
       w = [[GMSNavigationMutableWaypoint alloc]
-              initWithLocation:[ObjectTranslationUtil getLocationCoordinateFrom:wp[@"position"]]
-                         title:wp[@"title"]
-          preferSameSideOfRoad:wp[@"preferSameSideOfRoad"]];
-      w.vehicleStopover = wp[@"vehicleStopover"];
+        initWithLocation:[ObjectTranslationUtil getLocationCoordinateFrom:wp[@"position"]]
+                    title:wp[@"title"]];   
+    } else {
+      // The validation will be done on the client, so just ignore this waypoint here.
+      continue;
     }
 
-    if (![placeId isEqual:@""]) {
-      w = [[GMSNavigationMutableWaypoint alloc] initWithPlaceID:placeId title:wp[@"title"]];
-      w.vehicleStopover = wp[@"vehicleStopover"];
-      w.preferSameSideOfRoad = wp[@"preferSameSideOfRoad"];
+    if (wp[@"preferSameSideOfRoad"] != nil) {
+      w.preferSameSideOfRoad = [wp[@"preferSameSideOfRoad"] boolValue];
     }
+
+    if (wp[@"vehicleStopover"] != nil) {
+      w.vehicleStopover = [wp[@"vehicleStopover"] boolValue]; 
+    }    
 
     if (wp[@"preferredHeading"] != nil) {
       w.preferredHeading = [wp[@"preferredHeading"] intValue];

--- a/ios/react-native-navigation-sdk/RCTNavViewManager.m
+++ b/ios/react-native-navigation-sdk/RCTNavViewManager.m
@@ -250,14 +250,6 @@ RCT_EXPORT_METHOD(removeGroundOverlay:(nonnull NSNumber *)reactTag params:(NSStr
   });
 }
 
-RCT_EXPORT_METHOD(setDestination: (nonnull NSNumber *)reactTag 
-                  waypoints: (nonnull NSArray *)waypoints
-                  routingOptions: (NSDictionary *)routingOptions) {
-  dispatch_async(dispatch_get_main_queue(), ^{
-      [viewController setDestinations:waypoints withRoutingOptions: routingOptions];
-  });
-}
-
 RCT_EXPORT_METHOD(setDestinations: (nonnull NSNumber *)reactTag 
                   waypoints: (nonnull NSArray *)waypoints
                   routingOptions: (NSDictionary *)routingOptions) {


### PR DESCRIPTION
fix: address crash on single destination navigation due to invalid waypoint

The cause was an incorrect condition that assumed that a waypoint should always be created with a PlaceID (and the constructor on the native side returns nil when `placeId` is nil too).

Fixes #17 

