### PR TITLE
fix: address missing logDebugInfo on iOS

### DIFF
--- a/ios/react-native-navigation-sdk/CustomEventDispatcher.m
+++ b/ios/react-native-navigation-sdk/CustomEventDispatcher.m
@@ -51,6 +51,7 @@ RCT_EXPORT_MODULE(CustomEventDispatcher);
     @"onPolylineClick",
     @"onPolygonClick",
     @"onCircleClick",
+    @"logDebugInfo",
   ];
 }
 


### PR DESCRIPTION
fix: address missing logDebugInfo on iOS

Manually tested on the iOS sample app