### PR TITLE
chore: bump Android NavSDK to latest available (5.2.3)

### DIFF
--- a/SampleApp/android/app/build.gradle
+++ b/SampleApp/android/app/build.gradle
@@ -14,12 +14,6 @@
 plugins {
     id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.5"
 }
-
-repositories {
-    maven {
-        url "artifactregistry://us-west2-maven.pkg.dev/gmp-artifacts/transportation"
-    }
-}
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,6 @@
 
 import groovy.json.JsonSlurper
 
-
 def getApiKey(){
     def Properties props = new Properties()
     props.load(new FileInputStream(new File('local.properties')))
@@ -29,6 +28,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
     }
 }
 
@@ -36,10 +36,16 @@ plugins {
     id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.5"
 }
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     buildToolsVersion = "31.0.0"
     compileSdkVersion = 31
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         minSdkVersion 23
@@ -49,35 +55,23 @@ android {
         versionName "1.0"
         manifestPlaceholders = [ MAPS_API_KEY:getApiKey()]
     }
+
     lintOptions {
         abortOnError false
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }
 
 repositories {
     google()
     mavenCentral()
-    maven {
-        url "artifactregistry://us-west2-maven.pkg.dev/gmp-artifacts/transportation"
-    }
 }
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.google.android.libraries.navigation:navigation:4.5.0'
-    
-    api "org.chromium.net:cronet-fallback:76.3809.111"
-    api "joda-time:joda-time:2.10.14"
-    api "com.google.android.datatransport:transport-api:3.0.0"
-    api "com.google.android.datatransport:transport-backend-cct:3.1.4"
-    api "com.google.android.datatransport:transport-runtime:3.1.4"
-    api 'com.github.bumptech.glide:glide:4.9.0'
-    api 'com.github.bumptech.glide:okhttp-integration:4.9.0'
-    api "androidx.mediarouter:mediarouter:1.3.0"
-    api 'com.google.guava:guava:31.0.1-android'
-
+    implementation 'com.google.android.libraries.navigation:navigation:5.2.3"
 }


### PR DESCRIPTION
chore: bump Android NavSDK to latest available (5.2.3)

The current version is beyond it's build horizon and it's no longer supported.