### PR TITLE
chore: bump package.json in preparation for minor release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "name": "react-native-navigation-sdk",
-  "version": "0.1.5-beta",
+  "version": "0.2.0-beta",
   "author": "Google",
   "description": "A react-native library for Google's Navigation SDK",
   "private": false,
   "license": "UNLICENSED",
   "repository": {
     "type": "git",
-    "url": "https://FILL_ONCE_AVAILABLE"
+    "url": "https://github.com/googlemaps/react-native-navigation-sdk"
   },
   "bugs": {
-    "url": "https://FILL_ONCE_AVAILABLE"
+    "url": "https://github.com/googlemaps/react-native-navigation-sdk/issues"
   },
-  "homepage": "https://FILL_ONCE_AVAILABLE",
+  "homepage": "https://github.com/googlemaps/react-native-navigation-sdk",
   "keywords": [
     "react-native",
     "android",


### PR DESCRIPTION
This bumps the package json in preparation for the 0.2.0-beta minor release. 
The release contains:

- Bump to Android NavSDK 5.2.3
- Migrates to KT 1.9
- Bump to iOS NavSDK 5.4.0
- Minor bug fixes