### PR TITLE
fix: stop forcing users to supply api key via local.properties on And…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,31 @@ android {
 }
 ```
 
-1. To securely store your API key, it is recommended to use the [Google Maps Secrets Gradle Plugin](https://developers.google.com/maps/documentation/android-sdk/secrets-gradle-plugin). This plugin helps manage API keys without exposing them in your app's source code.
+To securely store your API key, it is recommended to use the [Google Maps Secrets Gradle Plugin](https://developers.google.com/maps/documentation/android-sdk/secrets-gradle-plugin). This plugin helps manage API keys without exposing them in your app's source code.
 
 See example configuration for secrets plugin at example applications [build.gradle](./SampleApp/android/app/build.gradle) file.
 
 ### iOS
 
-1. Set the iOS version in your application PodFile.
+To set up, specify your API key in the application delegate `ios/Runner/AppDelegate.m`:
 
-   `platform: ios, '14.0'`
+```objective-c
+@implementation AppDelegate
 
-1. Make sure to run `pod install` from your application `ios` module.
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  [GMSServices provideAPIKey:@"API_KEY"];
+  [GMSServices setMetalRendererEnabled:YES];
+  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
 
-1. To set up, store your API key in the application plist file ([example](./SampleApp/ios/SampleApp/Info.plist), the key is defined under the API_KEY value). Then you need to update your [AppDelegate](./SampleApp/ios/SampleApp/AppDelegate.mm) file so the key can be read.
+```
 
+[!NOTE]Above code snipped also enables Metal rendering for Google Maps SDK. If you are not using Metal rendering, you can remove the following line:
+  
+```objective-c
+[GMSServices setMetalRendererEnabled:YES];
+```
 
 ## Usage
 

--- a/SampleApp/android/app/build.gradle
+++ b/SampleApp/android/app/build.gradle
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-plugins {
-    id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.5"
-}
+
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
+apply plugin: 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -134,6 +133,22 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+}
+
+secrets {
+    // This example application employs the Gradle plugin
+    // com.google.android.libraries.mapsplatform.secrets-gradle-plugin
+    // to securely manage the Google Maps API key.
+    // For more information on the plugin, visit:
+    // https://developers.google.com/maps/documentation/android-sdk/secrets-gradle-plugin
+    propertiesFileName = "local.properties"
+
+    // For CI/CD, you can have a file with default keys that can be 
+    // safely checked in to your source code version control.
+    // defaultPropertiesFileName = 'local.defaults.properties'
+
+    // Ignore all keys matching the regexp "sdk.*"
+    ignoreList.add("sdk.*")    
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/SampleApp/android/app/src/main/AndroidManifest.xml
+++ b/SampleApp/android/app/src/main/AndroidManifest.xml
@@ -37,5 +37,9 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+
+      <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}" />
     </application>
 </manifest>

--- a/SampleApp/android/build.gradle
+++ b/SampleApp/android/build.gradle
@@ -31,5 +31,13 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
+        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,12 +14,6 @@
 
 import groovy.json.JsonSlurper
 
-def getApiKey(){
-    def Properties props = new Properties()
-    props.load(new FileInputStream(new File('local.properties')))
-    return props['MAPS_API_KEY']
-}
-
 buildscript {
     repositories {
         google()
@@ -32,9 +26,6 @@ buildscript {
     }
 }
 
-plugins {
-    id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.5"
-}
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
@@ -53,7 +44,6 @@ android {
         versionCode 1
         // get version name from package.json version
         versionName "1.0"
-        manifestPlaceholders = [ MAPS_API_KEY:getApiKey()]
     }
 
     lintOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -24,10 +24,6 @@
         <service
             android:name="com.google.android.react.navsdk.NavInfoReceivingService"
             android:exported="false" />
-
-        <meta-data
-            android:name="com.google.android.geo.API_KEY"
-            android:value="${MAPS_API_KEY}" />
     </application>
 
 </manifest>


### PR DESCRIPTION
The current approach forces users to have a local.properties file to be able to provide the API key for Android. This doesn't work beyond local environments as the local.properties files shouldn't be checked (#129)

This PR makes it flexible for end apps to define their own way to provide the API key. And also updates the sample app to provide a sample case on how to achieve this.

This is consistent with the Flutter Maps plugin and native Android NavSDK:
https://developers.google.com/maps/flutter-package/config#step_4_add_your_api_key_to_the_project