### PR TITLE
chore: bump package.json for minor preview release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-sdk",
-  "version": "0.2.3-beta",
+  "version": "0.3.0-beta",
   "author": "Google",
   "description": "A react-native library for Google's Navigation SDK",
   "private": false,


### PR DESCRIPTION
Fixes #129 

This release stops forcing users to provide a "local.properties" file with a MAPS_API_KEY, which can be an issue for CI/CD as this file isn't meant to be checked in. Instead, now we leave it up to the users how to supply the key.  Our recommendation is to use the [secrets gradle plugin](https://developers.google.com/maps/documentation/android-sdk/secrets-gradle-plugin#installation-and-usage) which is used for Maps/NavSDK.