### PR TITLE
fix: linting error caused by not enforcing key type for dictionary

### DIFF
--- a/components/navigation/navigationView/index.tsx
+++ b/components/navigation/navigationView/index.tsx
@@ -41,7 +41,7 @@ import {ArrivalEvent, NavigationViewProps} from './types';
 export default class NavigationView extends React.Component<NavigationViewProps> {
   private viewId: number = -1;
   private mapViewRef?: any;
-  private nativeEventsToCallbackMap;
+  private nativeEventsToCallbackMap: { [key: string] : (event: any) => void };
 
   constructor(_props: NavigationViewProps) {
     super(_props);
@@ -361,7 +361,10 @@ export default class NavigationView extends React.Component<NavigationViewProps>
     );
 
     for (const eventName of Object.keys(this.nativeEventsToCallbackMap)) {
-      eventEmitter.addListener(eventName, this.nativeEventsToCallbackMap[eventName]);
+      const listener = this.nativeEventsToCallbackMap[eventName];
+      if (listener != undefined) {
+        eventEmitter.addListener(eventName, listener);
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-sdk",
-  "version": "0.3.0-beta",
+  "version": "0.3.1-beta",
   "author": "Google",
   "description": "A react-native library for Google's Navigation SDK",
   "private": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
-    "allowUnreachableCode": false,
-    "noImplicitAny": false,
+    "allowUnreachableCode": true,
+    "noImplicitAny": true,
     "moduleSuffixes": [".android", ".ios", ""]
   },
   "include": [


### PR DESCRIPTION
Fixes #136 

This also updates the tsconfig.json to be more strict in how we expect our Typescript to be defined. This is more in line 
with customer's usage.

This bumps the package version to do a patch with the fix.