### PR TITLE
chore: move publish into its own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -24,10 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
-        with:
-          go-version: '^1.13.1'
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
       - name: Install addlicense
         run: go install github.com/google/addlicense@latest
       - name: Check license header

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow that publishes the library to CocoaPods
+name: Publish
+
+on:
+  workflow_call: # called when release-please steps.release.outputs.release_created
+  workflow_dispatch: # manually trigger if previous runs failed
+
+concurrency:
+  group: publishing
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/ci.yml
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node for Dependency Installation
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm install
+
+      # Now configure node with the registry used for publishing
+      - name: Setup Node for Publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://wombat-dressing-room.appspot.com/"
+
+      - name: Publish
+        # npm publish will trigger the build via the prepack hook
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_WOMBOT_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,32 +47,9 @@ jobs:
       # Note the "if" statement on all commands to make sure that publishing
       # only happens when a release is cut.
 
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
       - if: ${{ steps.release.outputs.release_created }}
-        name: Setup Node for Dependency Installation
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Install Dependencies
-        run: npm install
-
-      # Now configure node with the registry used for publishing
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Setup Node for Publishing
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: "https://wombat-dressing-room.appspot.com/"
-
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Publish
-        # npm publish will trigger the build via the prepack hook
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_WOMBOT_TOKEN }}
+        name: Start publish
+        uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
- Adds ability to trigger publish workflow manually in case of failed automation from release-please.
- Adds requirement to pass CI verification before generating a release
- Adds requirement to pass CI verification before publishing to npm
- Renames licence-check.yml -> license-check.yml