### PR TITLE
chore: gitignore active api keys for iOS SampleApp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           NO_FLIPPER: 1
 
       - name: Copy Keys.plist file from sample
-        run: cp example/ios/SampleApp/Keys.plist.example example/ios/SampleApp/Keys.plist
+        run: cp example/ios/SampleApp/Keys.plist.sample example/ios/SampleApp/Keys.plist
 
       - name: Build example for iOS
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
         env:
           NO_FLIPPER: 1
 
+      - name: Copy Keys.plist file from sample
+        run: cp example/ios/SampleApp/Keys.plist.example example/ios/SampleApp/Keys.plist
+
       - name: Build example for iOS
         run: |
           yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 .xcode.env.local
+Keys.plist
 
 # Android/IJ
 #

--- a/example/README.md
+++ b/example/README.md
@@ -18,7 +18,7 @@ This contains a sample application to showcase the functionality of the NavSDK l
 
    `pod install`
 
-4. In your Google cloud console, add the Google API key to the project. Add this newly created API key to the Info.plist file inside `example/ios/SampleApp/`.
+4. Copy the `Keys.plist.sample` file located in `example/ios/SampleApp/` to a new file named `Keys.plist`. This file is git ignored and won't be accidentally committed. In your Google cloud console, add the Google API key to the project and add this newly created API key to the `Keys.plist` file.
 
     ```xml
     <key>API_KEY</key>

--- a/example/ios/SampleApp.xcodeproj/project.pbxproj
+++ b/example/ios/SampleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		52D4271D2C81D3F300C7FB36 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 52D4271C2C81D3F300C7FB36 /* Keys.plist */; };
 		7699B88040F8A987B510C191 /* libPods-SampleApp-SampleAppTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-SampleApp-SampleAppTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		E72EC806AB287A94E8141AD5 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E049A7A79160D0D74CDA8CD1 /* PrivacyInfo.xcprivacy */; };
@@ -40,6 +41,7 @@
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = SampleApp/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-SampleApp-SampleAppTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SampleApp-SampleAppTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-SampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleApp.debug.xcconfig"; path = "Target Support Files/Pods-SampleApp/Pods-SampleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		52D4271C2C81D3F300C7FB36 /* Keys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Keys.plist; path = SampleApp/Keys.plist; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-SampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleApp.release.xcconfig"; path = "Target Support Files/Pods-SampleApp/Pods-SampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-SampleApp-SampleAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleApp-SampleAppTests.debug.xcconfig"; path = "Target Support Files/Pods-SampleApp-SampleAppTests/Pods-SampleApp-SampleAppTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-SampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -93,6 +95,7 @@
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
+				52D4271C2C81D3F300C7FB36 /* Keys.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
@@ -246,6 +249,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				52D4271D2C81D3F300C7FB36 /* Keys.plist in Resources */,
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				E72EC806AB287A94E8141AD5 /* PrivacyInfo.xcprivacy in Resources */,

--- a/example/ios/SampleApp/AppDelegate.mm
+++ b/example/ios/SampleApp/AppDelegate.mm
@@ -26,8 +26,15 @@
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
-  NSString *api_key =
-      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"API_KEY"];
+  
+  // Note: Ensure that you have copied the Keys.plist.sample to Keys.plist
+  // and have added the correct API_KEY value to the file.
+  //
+  // Get the path for the Keys.plist file in the main bundle and read API_KEY.
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"Keys" ofType:@"plist"];
+  NSDictionary *keysDictionary = [NSDictionary dictionaryWithContentsOfFile:path];
+  NSString *api_key = [keysDictionary objectForKey:@"API_KEY"];
+  
   [GMSServices provideAPIKey:api_key];
   [GMSServices setMetalRendererEnabled:YES];
   return [super application:application

--- a/example/ios/SampleApp/Info.plist
+++ b/example/ios/SampleApp/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>API_KEY</key>
-	<string>[Add your key]</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/example/ios/SampleApp/Keys.plist.sample
+++ b/example/ios/SampleApp/Keys.plist.sample
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>[Add your key]</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR moves API keys to a separate Keys.plist file for SampleApp, which is added to .gitignore. Developers should copy Keys.plist.sample as Keys.plist and update their API keys accordingly. This change helps prevent accidental commits of sensitive API keys.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR