### PR TITLE
fix: ensure EventDispatcher always receives non-null data from NavViewEvent

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
@@ -24,6 +24,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
@@ -697,6 +698,9 @@ public class NavViewFragment extends SupportNavigationFragment {
 
     @Override
     public WritableMap getEventData() {
+      if (eventData == null) {
+        return Arguments.createMap();
+      }
       return eventData;
     }
   }


### PR DESCRIPTION
Fixes #252

This PR addresses the issue where the `EventDispatcher` on Android implementation could potentially receive null data from the `NavViewEvent` `getEventData()` method, leading to crashes in specific cases (such as during the `onMapReady` event).

**Changes:**
Updated getEventData() in NavViewEvent to return an empty WritableMap when eventData is null.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR