### PR TITLE
feat: map view without navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ To set up, specify your API key in the application delegate `ios/Runner/AppDeleg
 
 ## Usage
 
+### Add a navigation view
+
 You can now add a `NavigationView` component to your application..
 
 The view can be controlled with the `ViewController` (Navigation and MapView) that are retrieved from the `onMapViewControllerCreated` and `onNavigationViewControllerCreated` (respectively).
 
 The `NavigationView` compoonent should be used within a View with a bounded size. Using it
 in an unbounded widget will cause the application to behave unexpectedly.
-
-### Add a navigation view
 
 ```tsx
     // Permissions must have been granted by this point.
@@ -103,6 +103,17 @@ in an unbounded widget will cause the application to behave unexpectedly.
         onNavigationViewControllerCreated={setNavigationViewController}
         termsAndConditionsDialogOptions={termsAndConditionsDialogOptions}
     />
+```
+
+### Add a map view
+
+You can also add a bare `MapView` that works as a normal map view without navigation functionality. `MapView` only need a `MapViewController` to be controlled.
+
+```tsx
+<MapView
+    mapViewCallbacks={mapViewCallbacks}
+    onMapViewControllerCreated={setMapViewController}
+/>
 ```
 
 See the [example](./example) directory for a complete navigation sample app.

--- a/android/src/main/java/com/google/android/react/navsdk/CustomTypes.java
+++ b/android/src/main/java/com/google/android/react/navsdk/CustomTypes.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.react.navsdk;
+
+public class CustomTypes {
+  public enum FragmentType {
+    MAP,
+    NAVIGATION
+  }
+}

--- a/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
+++ b/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
@@ -80,4 +80,14 @@ public class EnumTranslationUtil {
         return CameraPerspective.TILTED;
     }
   }
+
+  public static CustomTypes.FragmentType getFragmentTypeFromJsValue(int jsValue) {
+    switch (jsValue) {
+      case 0:
+      default:
+        return CustomTypes.FragmentType.MAP;
+      case 1:
+        return CustomTypes.FragmentType.NAVIGATION;
+    }
+  }
 }

--- a/android/src/main/java/com/google/android/react/navsdk/IMapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/IMapViewFragment.java
@@ -25,7 +25,7 @@ import com.google.android.gms.maps.model.Polyline;
 import java.io.IOException;
 import java.util.Map;
 
-public interface IViewFragment {
+public interface IMapViewFragment {
   void setStylingOptions(Map stylingOptions);
   void applyStylingOptions();
   void setFollowingPerspective(int jsValue);
@@ -62,17 +62,6 @@ public interface IViewFragment {
   void setMapToolbarEnabled(boolean isOn);
   void setMyLocationButtonEnabled(boolean isOn);
   GoogleMap getGoogleMap();
-
-  // Navigation
-  void setNavigationUiEnabled(boolean enableNavigationUi);
-  void setTripProgressBarEnabled(boolean enabled);
-  void setSpeedometerEnabled(boolean enabled);
-  void setSpeedLimitIconEnabled(boolean enabled);
-  void setTrafficIncidentCardsEnabled(boolean enabled);
-  void setEtaCardEnabled(boolean enabled);
-  void setHeaderEnabled(boolean enabled);
-  void setRecenterButtonEnabled(boolean enabled);
-  void showRouteOverview();
 
   // Fragment
   boolean isAdded();

--- a/android/src/main/java/com/google/android/react/navsdk/IMapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/IMapViewFragment.java
@@ -14,56 +14,90 @@
 package com.google.android.react.navsdk;
 
 import android.view.View;
-
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
-
 import java.io.IOException;
 import java.util.Map;
 
 public interface IMapViewFragment {
   void setStylingOptions(Map stylingOptions);
+
   void applyStylingOptions();
+
   void setFollowingPerspective(int jsValue);
+
   void setNightModeOption(int jsValue);
+
   void setMapType(int jsValue);
+
   void clearMapView();
+
   void resetMinMaxZoomLevel();
+
   void animateCamera(Map map);
+
   Circle addCircle(Map optionsMap);
+
   Marker addMarker(Map optionsMap);
+
   Polyline addPolyline(Map optionsMap);
+
   Polygon addPolygon(Map optionsMap);
+
   void removeMarker(String id);
+
   void removePolyline(String id);
+
   void removePolygon(String id);
+
   void removeCircle(String id);
+
   void removeGroundOverlay(String id);
+
   GroundOverlay addGroundOverlay(Map map);
+
   void setMapStyle(String url);
+
   String fetchJsonFromUrl(String urlString) throws IOException;
+
   void moveCamera(Map map);
+
   void setZoomLevel(int level);
+
   void setIndoorEnabled(boolean isOn);
+
   void setTrafficEnabled(boolean isOn);
+
   void setCompassEnabled(boolean isOn);
+
   void setRotateGesturesEnabled(boolean isOn);
+
   void setScrollGesturesEnabled(boolean isOn);
+
   void setScrollGesturesEnabledDuringRotateOrZoom(boolean isOn);
+
   void setTiltGesturesEnabled(boolean isOn);
+
   void setZoomControlsEnabled(boolean isOn);
+
   void setZoomGesturesEnabled(boolean isOn);
+
   void setBuildingsEnabled(boolean isOn);
+
   void setMyLocationEnabled(boolean isOn);
+
   void setMapToolbarEnabled(boolean isOn);
+
   void setMyLocationButtonEnabled(boolean isOn);
+
   GoogleMap getGoogleMap();
 
   // Fragment
   boolean isAdded();
+
   View getView();
 }

--- a/android/src/main/java/com/google/android/react/navsdk/INavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/INavViewFragment.java
@@ -15,12 +15,20 @@ package com.google.android.react.navsdk;
 
 public interface INavViewFragment extends IMapViewFragment {
   void setNavigationUiEnabled(boolean enableNavigationUi);
+
   void setTripProgressBarEnabled(boolean enabled);
+
   void setSpeedometerEnabled(boolean enabled);
+
   void setSpeedLimitIconEnabled(boolean enabled);
+
   void setTrafficIncidentCardsEnabled(boolean enabled);
+
   void setEtaCardEnabled(boolean enabled);
+
   void setHeaderEnabled(boolean enabled);
+
   void setRecenterButtonEnabled(boolean enabled);
+
   void showRouteOverview();
 }

--- a/android/src/main/java/com/google/android/react/navsdk/INavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/INavViewFragment.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.react.navsdk;
+
+public interface INavViewFragment extends IMapViewFragment {
+  void setNavigationUiEnabled(boolean enableNavigationUi);
+  void setTripProgressBarEnabled(boolean enabled);
+  void setSpeedometerEnabled(boolean enabled);
+  void setSpeedLimitIconEnabled(boolean enabled);
+  void setTrafficIncidentCardsEnabled(boolean enabled);
+  void setEtaCardEnabled(boolean enabled);
+  void setHeaderEnabled(boolean enabled);
+  void setRecenterButtonEnabled(boolean enabled);
+  void showRouteOverview();
+}

--- a/android/src/main/java/com/google/android/react/navsdk/IViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/IViewFragment.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.react.navsdk;
+
+import android.view.View;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Circle;
+import com.google.android.gms.maps.model.GroundOverlay;
+import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.Polygon;
+import com.google.android.gms.maps.model.Polyline;
+
+import java.io.IOException;
+import java.util.Map;
+
+public interface IViewFragment {
+  boolean isNavigationSupportedOnMap();
+  void setStylingOptions(Map stylingOptions);
+  void applyStylingOptions();
+  void setFollowingPerspective(int jsValue);
+  void setNightModeOption(int jsValue);
+  void setMapType(int jsValue);
+  void clearMapView();
+  void resetMinMaxZoomLevel();
+  void animateCamera(Map map);
+  Circle addCircle(Map optionsMap);
+  Marker addMarker(Map optionsMap);
+  Polyline addPolyline(Map optionsMap);
+  Polygon addPolygon(Map optionsMap);
+  void removeMarker(String id);
+  void removePolyline(String id);
+  void removePolygon(String id);
+  void removeCircle(String id);
+  void removeGroundOverlay(String id);
+  GroundOverlay addGroundOverlay(Map map);
+  void setMapStyle(String url);
+  String fetchJsonFromUrl(String urlString) throws IOException;
+  void moveCamera(Map map);
+  void setZoomLevel(int level);
+  void setIndoorEnabled(boolean isOn);
+  void setTrafficEnabled(boolean isOn);
+  void setCompassEnabled(boolean isOn);
+  void setRotateGesturesEnabled(boolean isOn);
+  void setScrollGesturesEnabled(boolean isOn);
+  void setScrollGesturesEnabledDuringRotateOrZoom(boolean isOn);
+  void setTiltGesturesEnabled(boolean isOn);
+  void setZoomControlsEnabled(boolean isOn);
+  void setZoomGesturesEnabled(boolean isOn);
+  void setBuildingsEnabled(boolean isOn);
+  void setMyLocationEnabled(boolean isOn);
+  void setMapToolbarEnabled(boolean isOn);
+  void setMyLocationButtonEnabled(boolean isOn);
+  GoogleMap getGoogleMap();
+
+  // Navigation
+  void setNavigationUiEnabled(boolean enableNavigationUi);
+  void setTripProgressBarEnabled(boolean enabled);
+  void setSpeedometerEnabled(boolean enabled);
+  void setSpeedLimitIconEnabled(boolean enabled);
+  void setTrafficIncidentCardsEnabled(boolean enabled);
+  void setEtaCardEnabled(boolean enabled);
+  void setHeaderEnabled(boolean enabled);
+  void setRecenterButtonEnabled(boolean enabled);
+  void showRouteOverview();
+
+  // Fragment
+  boolean isAdded();
+  View getView();
+}

--- a/android/src/main/java/com/google/android/react/navsdk/IViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/IViewFragment.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.Map;
 
 public interface IViewFragment {
-  boolean isNavigationSupportedOnMap();
   void setStylingOptions(Map stylingOptions);
   void applyStylingOptions();
   void setFollowingPerspective(int jsValue);

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
@@ -33,8 +33,8 @@ import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.Event;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.MapFragment;
 import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.CameraPosition;
@@ -68,7 +68,7 @@ import java.util.concurrent.Executors;
  * This fragment's lifecycle is managed by NavViewManager.
  */
 @SuppressLint("ValidFragment")
-public class MapViewFragment extends MapFragment implements IViewFragment {
+public class MapViewFragment extends SupportMapFragment implements IViewFragment {
   private static final String TAG = "MapViewFragment";
   private GoogleMap mGoogleMap;
   private StylingOptions mStylingOptions;
@@ -146,10 +146,6 @@ public class MapViewFragment extends MapFragment implements IViewFragment {
         });
       }
     });
-  }
-
-  public boolean isNavigationSupportedOnMap() {
-    return false;
   }
 
   public void applyStylingOptions() {}
@@ -629,18 +625,6 @@ public class MapViewFragment extends MapFragment implements IViewFragment {
     });
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    cleanup();
-  }
-
-  @Override
-  public void onDestroyView() {
-    super.onDestroyView();
-    cleanup();
-  }
-
   private void emitEvent(String eventName, @Nullable WritableMap data) {
     if (reactContext != null) {
       EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewTag);
@@ -674,8 +658,6 @@ public class MapViewFragment extends MapFragment implements IViewFragment {
   public void setRecenterButtonEnabled(boolean enabled) {}
 
   public void showRouteOverview() {}
-
-  private void cleanup() {}
 
   public class NavViewEvent extends Event<NavViewEvent> {
     private String eventName;

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
@@ -19,18 +19,16 @@ import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.EventDispatcher;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -51,7 +49,6 @@ import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
 import com.google.android.libraries.navigation.StylingOptions;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,8 +61,8 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 
 /**
- * A fragment that displays a view with a Google Map using MapFragment.
- * This fragment's lifecycle is managed by NavViewManager.
+ * A fragment that displays a view with a Google Map using MapFragment. This fragment's lifecycle is
+ * managed by NavViewManager.
  */
 @SuppressLint("ValidFragment")
 public class MapViewFragment extends SupportMapFragment implements IMapViewFragment {
@@ -84,7 +81,8 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
   public MapViewFragment(ReactApplicationContext reactContext, int viewTag) {
     this.reactContext = reactContext;
     this.viewTag = viewTag;
-  };
+  }
+  ;
 
   private String style = "";
 
@@ -93,59 +91,71 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    getMapAsync(new OnMapReadyCallback() {
-      public void onMapReady(GoogleMap googleMap) {
-        mGoogleMap = googleMap;
+    getMapAsync(
+        new OnMapReadyCallback() {
+          public void onMapReady(GoogleMap googleMap) {
+            mGoogleMap = googleMap;
 
-        emitEvent("onMapReady", null);
+            emitEvent("onMapReady", null);
 
-        mGoogleMap.setOnMarkerClickListener(new GoogleMap.OnMarkerClickListener() {
-          @Override
-          public boolean onMarkerClick(Marker marker) {
-            emitEvent("onMarkerClick", ObjectTranslationUtil.getMapFromMarker(marker));
-            return false;
-          }
-        });
-        mGoogleMap.setOnPolylineClickListener(new GoogleMap.OnPolylineClickListener() {
-          @Override
-          public void onPolylineClick(Polyline polyline) {
-            emitEvent("onPolylineClick", ObjectTranslationUtil.getMapFromPolyline(polyline));
-          }
-        });
-        mGoogleMap.setOnPolygonClickListener(new GoogleMap.OnPolygonClickListener() {
-          @Override
-          public void onPolygonClick(Polygon polygon) {
-            emitEvent("onPolygonClick", ObjectTranslationUtil.getMapFromPolygon(polygon));
-          }
-        });
-        mGoogleMap.setOnCircleClickListener(new GoogleMap.OnCircleClickListener() {
-          @Override
-          public void onCircleClick(Circle circle) {
-            emitEvent("onCircleClick", ObjectTranslationUtil.getMapFromCircle(circle));
-          }
-        });
-        mGoogleMap.setOnGroundOverlayClickListener(new GoogleMap.OnGroundOverlayClickListener() {
-          @Override
-          public void onGroundOverlayClick(GroundOverlay groundOverlay) {
-            emitEvent("onGroundOverlayClick", ObjectTranslationUtil.getMapFromGroundOverlay(groundOverlay));
-          }
-        });
+            mGoogleMap.setOnMarkerClickListener(
+                new GoogleMap.OnMarkerClickListener() {
+                  @Override
+                  public boolean onMarkerClick(Marker marker) {
+                    emitEvent("onMarkerClick", ObjectTranslationUtil.getMapFromMarker(marker));
+                    return false;
+                  }
+                });
+            mGoogleMap.setOnPolylineClickListener(
+                new GoogleMap.OnPolylineClickListener() {
+                  @Override
+                  public void onPolylineClick(Polyline polyline) {
+                    emitEvent(
+                        "onPolylineClick", ObjectTranslationUtil.getMapFromPolyline(polyline));
+                  }
+                });
+            mGoogleMap.setOnPolygonClickListener(
+                new GoogleMap.OnPolygonClickListener() {
+                  @Override
+                  public void onPolygonClick(Polygon polygon) {
+                    emitEvent("onPolygonClick", ObjectTranslationUtil.getMapFromPolygon(polygon));
+                  }
+                });
+            mGoogleMap.setOnCircleClickListener(
+                new GoogleMap.OnCircleClickListener() {
+                  @Override
+                  public void onCircleClick(Circle circle) {
+                    emitEvent("onCircleClick", ObjectTranslationUtil.getMapFromCircle(circle));
+                  }
+                });
+            mGoogleMap.setOnGroundOverlayClickListener(
+                new GoogleMap.OnGroundOverlayClickListener() {
+                  @Override
+                  public void onGroundOverlayClick(GroundOverlay groundOverlay) {
+                    emitEvent(
+                        "onGroundOverlayClick",
+                        ObjectTranslationUtil.getMapFromGroundOverlay(groundOverlay));
+                  }
+                });
 
-        mGoogleMap.setOnInfoWindowClickListener(new GoogleMap.OnInfoWindowClickListener() {
-          @Override
-          public void onInfoWindowClick(Marker marker) {
-            emitEvent("onMarkerInfoWindowTapped", ObjectTranslationUtil.getMapFromMarker(marker));
-          }
-        });
+            mGoogleMap.setOnInfoWindowClickListener(
+                new GoogleMap.OnInfoWindowClickListener() {
+                  @Override
+                  public void onInfoWindowClick(Marker marker) {
+                    emitEvent(
+                        "onMarkerInfoWindowTapped", ObjectTranslationUtil.getMapFromMarker(marker));
+                  }
+                });
 
-        mGoogleMap.setOnMapClickListener(new GoogleMap.OnMapClickListener() {
-          @Override
-          public void onMapClick(LatLng latLng) {
-            emitEvent("onMapClick", ObjectTranslationUtil.getMapFromLatLng(latLng));
+            mGoogleMap.setOnMapClickListener(
+                new GoogleMap.OnMapClickListener() {
+                  @Override
+                  public void onMapClick(LatLng latLng) {
+                    emitEvent("onMapClick", ObjectTranslationUtil.getMapFromLatLng(latLng));
+                  }
+                });
           }
         });
-      }
-    });
   }
 
   public void applyStylingOptions() {}
@@ -195,17 +205,17 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
       int animationDuration = CollectionUtil.getInt("duration", map, 0);
 
       CameraPosition cameraPosition =
-        new CameraPosition.Builder()
-          .target(
-            ObjectTranslationUtil.getLatLngFromMap(
-              (Map) map.get("target"))) // Set the target location
-          .zoom(zoom) // Set the desired zoom level
-          .tilt(tilt) // Set the desired tilt angle (0 for straight down, 90 for straight up)
-          .bearing(bearing) // Set the desired bearing (rotation angle in degrees)
-          .build();
+          new CameraPosition.Builder()
+              .target(
+                  ObjectTranslationUtil.getLatLngFromMap(
+                      (Map) map.get("target"))) // Set the target location
+              .zoom(zoom) // Set the desired zoom level
+              .tilt(tilt) // Set the desired tilt angle (0 for straight down, 90 for straight up)
+              .bearing(bearing) // Set the desired bearing (rotation angle in degrees)
+              .build();
 
       mGoogleMap.animateCamera(
-        CameraUpdateFactory.newCameraPosition(cameraPosition), animationDuration, null);
+          CameraUpdateFactory.newCameraPosition(cameraPosition), animationDuration, null);
     }
   }
 
@@ -216,7 +226,8 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
 
     CircleOptions options = new CircleOptions();
 
-    float strokeWidth = Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
+    float strokeWidth =
+        Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
     options.strokeWidth(strokeWidth);
 
     double radius = CollectionUtil.getDouble("radius", optionsMap, 0.0);
@@ -255,7 +266,8 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
     String title = CollectionUtil.getString("title", optionsMap);
     String snippet = CollectionUtil.getString("snippet", optionsMap);
     float alpha = Double.valueOf(CollectionUtil.getDouble("alpha", optionsMap, 1)).floatValue();
-    float rotation = Double.valueOf(CollectionUtil.getDouble("rotation", optionsMap, 0)).floatValue();
+    float rotation =
+        Double.valueOf(CollectionUtil.getDouble("rotation", optionsMap, 0)).floatValue();
     boolean draggable = CollectionUtil.getBool("draggable", optionsMap, false);
     boolean flat = CollectionUtil.getBool("flat", optionsMap, false);
     boolean visible = CollectionUtil.getBool("visible", optionsMap, true);
@@ -329,7 +341,8 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
 
     String strokeColor = CollectionUtil.getString("strokeColor", optionsMap);
     String fillColor = CollectionUtil.getString("fillColor", optionsMap);
-    float strokeWidth = Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
+    float strokeWidth =
+        Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
     boolean clickable = CollectionUtil.getBool("clickable", optionsMap, false);
     boolean geodesic = CollectionUtil.getBool("geodesic", optionsMap, false);
     boolean visible = CollectionUtil.getBool("visible", optionsMap, true);
@@ -380,15 +393,16 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
   }
 
   public void removeMarker(String id) {
-    UiThreadUtil.runOnUiThread(() -> {
-      for (Marker m : markerList) {
-        if (m.getId().equals(id)) {
-          m.remove();
-          markerList.remove(m);
-          return;
-        }
-      }
-    });
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          for (Marker m : markerList) {
+            if (m.getId().equals(id)) {
+              m.remove();
+              markerList.remove(m);
+              return;
+            }
+          }
+        });
   }
 
   public void removePolyline(String id) {
@@ -450,7 +464,8 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
     String imagePath = CollectionUtil.getString("imgPath", map);
     float width = Double.valueOf(CollectionUtil.getDouble("width", map, 0)).floatValue();
     float height = Double.valueOf(CollectionUtil.getDouble("height", map, 0)).floatValue();
-    float transparency = Double.valueOf(CollectionUtil.getDouble("transparency", map, 0)).floatValue();
+    float transparency =
+        Double.valueOf(CollectionUtil.getDouble("transparency", map, 0)).floatValue();
     boolean clickable = CollectionUtil.getBool("clickable", map, false);
     boolean visible = CollectionUtil.getBool("visible", map, true);
 
@@ -477,17 +492,22 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
   }
 
   public void setMapStyle(String url) {
-    Executors.newSingleThreadExecutor().execute(() -> {
-      try {
-        style = fetchJsonFromUrl(url);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-      getActivity().runOnUiThread((Runnable) () -> {
-        MapStyleOptions options = new MapStyleOptions(style);
-        mGoogleMap.setMapStyle(options);
-      });
-    });
+    Executors.newSingleThreadExecutor()
+        .execute(
+            () -> {
+              try {
+                style = fetchJsonFromUrl(url);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+              getActivity()
+                  .runOnUiThread(
+                      (Runnable)
+                          () -> {
+                            MapStyleOptions options = new MapStyleOptions(style);
+                            mGoogleMap.setMapStyle(options);
+                          });
+            });
   }
 
   public String fetchJsonFromUrl(String urlString) throws IOException {
@@ -513,10 +533,7 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
     }
   }
 
-
-  /**
-   * Moves the position of the camera to hover over Melbourne.
-   */
+  /** Moves the position of the camera to hover over Melbourne. */
   public void moveCamera(Map map) {
     LatLng latLng = ObjectTranslationUtil.getLatLngFromMap((Map) map.get("target"));
 
@@ -524,7 +541,8 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
     float tilt = (float) CollectionUtil.getDouble("tilt", map, 0);
     float bearing = (float) CollectionUtil.getDouble("bearing", map, 0);
 
-    CameraPosition cameraPosition = CameraPosition.builder().target(latLng).zoom(zoom).tilt(tilt).bearing(bearing).build();
+    CameraPosition cameraPosition =
+        CameraPosition.builder().target(latLng).zoom(zoom).tilt(tilt).bearing(bearing).build();
 
     mGoogleMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
   }
@@ -598,9 +616,9 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
   public void setMyLocationEnabled(boolean isOn) {
     if (mGoogleMap != null) {
       if (ActivityCompat.checkSelfPermission(getActivity(), permission.ACCESS_FINE_LOCATION)
-        == PackageManager.PERMISSION_GRANTED
-        && ActivityCompat.checkSelfPermission(getActivity(), permission.ACCESS_COARSE_LOCATION)
-        == PackageManager.PERMISSION_GRANTED) {
+              == PackageManager.PERMISSION_GRANTED
+          && ActivityCompat.checkSelfPermission(getActivity(), permission.ACCESS_COARSE_LOCATION)
+              == PackageManager.PERMISSION_GRANTED) {
         mGoogleMap.setMyLocationEnabled(isOn);
       }
     }
@@ -612,22 +630,22 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
     }
   }
 
-  /**
-   * Toggles whether the location marker is enabled.
-   */
+  /** Toggles whether the location marker is enabled. */
   public void setMyLocationButtonEnabled(boolean isOn) {
     if (mGoogleMap == null) {
       return;
     }
 
-    UiThreadUtil.runOnUiThread(() -> {
-      mGoogleMap.getUiSettings().setMyLocationButtonEnabled(isOn);
-    });
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          mGoogleMap.getUiSettings().setMyLocationButtonEnabled(isOn);
+        });
   }
 
   private void emitEvent(String eventName, @Nullable WritableMap data) {
     if (reactContext != null) {
-      EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewTag);
+      EventDispatcher dispatcher =
+          UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewTag);
 
       if (dispatcher != null) {
         int surfaceId = UIManagerHelper.getSurfaceId(reactContext);
@@ -663,7 +681,8 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
     private String eventName;
     private @Nullable WritableMap eventData;
 
-    public NavViewEvent(int surfaceId, int viewTag, String eventName, @Nullable WritableMap eventData) {
+    public NavViewEvent(
+        int surfaceId, int viewTag, String eventName, @Nullable WritableMap eventData) {
       super(surfaceId, viewTag);
       this.eventName = eventName;
       this.eventData = eventData;
@@ -683,4 +702,3 @@ public class MapViewFragment extends SupportMapFragment implements IMapViewFragm
     }
   }
 }
-

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
@@ -68,7 +68,7 @@ import java.util.concurrent.Executors;
  * This fragment's lifecycle is managed by NavViewManager.
  */
 @SuppressLint("ValidFragment")
-public class MapViewFragment extends SupportMapFragment implements IViewFragment {
+public class MapViewFragment extends SupportMapFragment implements IMapViewFragment {
   private static final String TAG = "MapViewFragment";
   private GoogleMap mGoogleMap;
   private StylingOptions mStylingOptions;

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
@@ -19,18 +19,21 @@ import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.events.Event;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.MapFragment;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -47,9 +50,8 @@ import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
-import com.google.android.libraries.navigation.NavigationView;
 import com.google.android.libraries.navigation.StylingOptions;
-import com.google.android.libraries.navigation.SupportNavigationFragment;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,11 +64,12 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 
 /**
- * A fragment that displays a navigation view with a Google Map using SupportNavigationFragment.
+ * A fragment that displays a view with a Google Map using MapFragment.
  * This fragment's lifecycle is managed by NavViewManager.
  */
-public class NavViewFragment extends SupportNavigationFragment implements IViewFragment {
-  private static final String TAG = "NavViewFragment";
+@SuppressLint("ValidFragment")
+public class MapViewFragment extends MapFragment implements IViewFragment {
+  private static final String TAG = "MapViewFragment";
   private GoogleMap mGoogleMap;
   private StylingOptions mStylingOptions;
 
@@ -78,18 +81,10 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
   private int viewTag; // React native view tag.
   private ReactApplicationContext reactContext;
 
-  public NavViewFragment(ReactApplicationContext reactContext, int viewTag) {
+  public MapViewFragment(ReactApplicationContext reactContext, int viewTag) {
     this.reactContext = reactContext;
     this.viewTag = viewTag;
-  }
-
-  private NavigationView.OnRecenterButtonClickedListener onRecenterButtonClickedListener =
-      new NavigationView.OnRecenterButtonClickedListener() {
-        @Override
-        public void onRecenterButtonClick() {
-          emitEvent("onRecenterButtonClick", null);
-        }
-      };
+  };
 
   private String style = "";
 
@@ -98,102 +93,68 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    setNavigationUiEnabled(NavModule.getInstance().getNavigator() != null);
+    getMapAsync(new OnMapReadyCallback() {
+      public void onMapReady(GoogleMap googleMap) {
+        mGoogleMap = googleMap;
 
-    getMapAsync(
-        new OnMapReadyCallback() {
-          public void onMapReady(GoogleMap googleMap) {
-            mGoogleMap = googleMap;
+        emitEvent("onMapReady", null);
 
-            emitEvent("onMapReady", null);
-
-            setNavigationUiEnabled(NavModule.getInstance().getNavigator() != null);
-
-            mGoogleMap.setOnMarkerClickListener(
-                new GoogleMap.OnMarkerClickListener() {
-                  @Override
-                  public boolean onMarkerClick(Marker marker) {
-                    emitEvent("onMarkerClick", ObjectTranslationUtil.getMapFromMarker(marker));
-                    return false;
-                  }
-                });
-            mGoogleMap.setOnPolylineClickListener(
-                new GoogleMap.OnPolylineClickListener() {
-                  @Override
-                  public void onPolylineClick(Polyline polyline) {
-                    emitEvent(
-                        "onPolylineClick", ObjectTranslationUtil.getMapFromPolyline(polyline));
-                  }
-                });
-            mGoogleMap.setOnPolygonClickListener(
-                new GoogleMap.OnPolygonClickListener() {
-                  @Override
-                  public void onPolygonClick(Polygon polygon) {
-                    emitEvent("onPolygonClick", ObjectTranslationUtil.getMapFromPolygon(polygon));
-                  }
-                });
-            mGoogleMap.setOnCircleClickListener(
-                new GoogleMap.OnCircleClickListener() {
-                  @Override
-                  public void onCircleClick(Circle circle) {
-                    emitEvent("onCircleClick", ObjectTranslationUtil.getMapFromCircle(circle));
-                  }
-                });
-            mGoogleMap.setOnGroundOverlayClickListener(
-                new GoogleMap.OnGroundOverlayClickListener() {
-                  @Override
-                  public void onGroundOverlayClick(GroundOverlay groundOverlay) {
-                    emitEvent(
-                        "onGroundOverlayClick",
-                        ObjectTranslationUtil.getMapFromGroundOverlay(groundOverlay));
-                  }
-                });
-
-            mGoogleMap.setOnInfoWindowClickListener(
-                new GoogleMap.OnInfoWindowClickListener() {
-                  @Override
-                  public void onInfoWindowClick(Marker marker) {
-                    emitEvent(
-                        "onMarkerInfoWindowTapped", ObjectTranslationUtil.getMapFromMarker(marker));
-                  }
-                });
-
-            mGoogleMap.setOnMapClickListener(
-                new GoogleMap.OnMapClickListener() {
-                  @Override
-                  public void onMapClick(LatLng latLng) {
-                    emitEvent("onMapClick", ObjectTranslationUtil.getMapFromLatLng(latLng));
-                  }
-                });
+        mGoogleMap.setOnMarkerClickListener(new GoogleMap.OnMarkerClickListener() {
+          @Override
+          public boolean onMarkerClick(Marker marker) {
+            emitEvent("onMarkerClick", ObjectTranslationUtil.getMapFromMarker(marker));
+            return false;
+          }
+        });
+        mGoogleMap.setOnPolylineClickListener(new GoogleMap.OnPolylineClickListener() {
+          @Override
+          public void onPolylineClick(Polyline polyline) {
+            emitEvent("onPolylineClick", ObjectTranslationUtil.getMapFromPolyline(polyline));
+          }
+        });
+        mGoogleMap.setOnPolygonClickListener(new GoogleMap.OnPolygonClickListener() {
+          @Override
+          public void onPolygonClick(Polygon polygon) {
+            emitEvent("onPolygonClick", ObjectTranslationUtil.getMapFromPolygon(polygon));
+          }
+        });
+        mGoogleMap.setOnCircleClickListener(new GoogleMap.OnCircleClickListener() {
+          @Override
+          public void onCircleClick(Circle circle) {
+            emitEvent("onCircleClick", ObjectTranslationUtil.getMapFromCircle(circle));
+          }
+        });
+        mGoogleMap.setOnGroundOverlayClickListener(new GoogleMap.OnGroundOverlayClickListener() {
+          @Override
+          public void onGroundOverlayClick(GroundOverlay groundOverlay) {
+            emitEvent("onGroundOverlayClick", ObjectTranslationUtil.getMapFromGroundOverlay(groundOverlay));
           }
         });
 
-    Executors.newSingleThreadExecutor()
-        .execute(
-            () -> {
-              requireActivity()
-                  .runOnUiThread(
-                      (Runnable)
-                          () -> {
-                            super.addOnRecenterButtonClickedListener(
-                                onRecenterButtonClickedListener);
-                          });
-            });
+        mGoogleMap.setOnInfoWindowClickListener(new GoogleMap.OnInfoWindowClickListener() {
+          @Override
+          public void onInfoWindowClick(Marker marker) {
+            emitEvent("onMarkerInfoWindowTapped", ObjectTranslationUtil.getMapFromMarker(marker));
+          }
+        });
+
+        mGoogleMap.setOnMapClickListener(new GoogleMap.OnMapClickListener() {
+          @Override
+          public void onMapClick(LatLng latLng) {
+            emitEvent("onMapClick", ObjectTranslationUtil.getMapFromLatLng(latLng));
+          }
+        });
+      }
+    });
   }
 
   public boolean isNavigationSupportedOnMap() {
-    return true;
+    return false;
   }
 
-  public void applyStylingOptions() {
-    if (mStylingOptions != null) {
-      super.setStylingOptions(mStylingOptions);
-    }
-  }
+  public void applyStylingOptions() {}
 
-  public void setStylingOptions(Map stylingOptions) {
-    mStylingOptions = new StylingOptionsBuilder.Builder(stylingOptions).build();
-  }
+  public void setStylingOptions(Map stylingOptions) {}
 
   @SuppressLint("MissingPermission")
   public void setFollowingPerspective(int jsValue) {
@@ -204,9 +165,7 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     mGoogleMap.followMyLocation(EnumTranslationUtil.getCameraPerspectiveFromJsValue(jsValue));
   }
 
-  public void setNightModeOption(int jsValue) {
-    super.setForceNightMode(EnumTranslationUtil.getForceNightModeFromJsValue(jsValue));
-  }
+  public void setNightModeOption(int jsValue) {}
 
   public void setMapType(int jsValue) {
     if (mGoogleMap == null) {
@@ -240,17 +199,17 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
       int animationDuration = CollectionUtil.getInt("duration", map, 0);
 
       CameraPosition cameraPosition =
-          new CameraPosition.Builder()
-              .target(
-                  ObjectTranslationUtil.getLatLngFromMap(
-                      (Map) map.get("target"))) // Set the target location
-              .zoom(zoom) // Set the desired zoom level
-              .tilt(tilt) // Set the desired tilt angle (0 for straight down, 90 for straight up)
-              .bearing(bearing) // Set the desired bearing (rotation angle in degrees)
-              .build();
+        new CameraPosition.Builder()
+          .target(
+            ObjectTranslationUtil.getLatLngFromMap(
+              (Map) map.get("target"))) // Set the target location
+          .zoom(zoom) // Set the desired zoom level
+          .tilt(tilt) // Set the desired tilt angle (0 for straight down, 90 for straight up)
+          .bearing(bearing) // Set the desired bearing (rotation angle in degrees)
+          .build();
 
       mGoogleMap.animateCamera(
-          CameraUpdateFactory.newCameraPosition(cameraPosition), animationDuration, null);
+        CameraUpdateFactory.newCameraPosition(cameraPosition), animationDuration, null);
     }
   }
 
@@ -261,8 +220,7 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
 
     CircleOptions options = new CircleOptions();
 
-    float strokeWidth =
-        Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
+    float strokeWidth = Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
     options.strokeWidth(strokeWidth);
 
     double radius = CollectionUtil.getDouble("radius", optionsMap, 0.0);
@@ -301,8 +259,7 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     String title = CollectionUtil.getString("title", optionsMap);
     String snippet = CollectionUtil.getString("snippet", optionsMap);
     float alpha = Double.valueOf(CollectionUtil.getDouble("alpha", optionsMap, 1)).floatValue();
-    float rotation =
-        Double.valueOf(CollectionUtil.getDouble("rotation", optionsMap, 0)).floatValue();
+    float rotation = Double.valueOf(CollectionUtil.getDouble("rotation", optionsMap, 0)).floatValue();
     boolean draggable = CollectionUtil.getBool("draggable", optionsMap, false);
     boolean flat = CollectionUtil.getBool("flat", optionsMap, false);
     boolean visible = CollectionUtil.getBool("visible", optionsMap, true);
@@ -376,8 +333,7 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
 
     String strokeColor = CollectionUtil.getString("strokeColor", optionsMap);
     String fillColor = CollectionUtil.getString("fillColor", optionsMap);
-    float strokeWidth =
-        Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
+    float strokeWidth = Double.valueOf(CollectionUtil.getDouble("strokeWidth", optionsMap, 0)).floatValue();
     boolean clickable = CollectionUtil.getBool("clickable", optionsMap, false);
     boolean geodesic = CollectionUtil.getBool("geodesic", optionsMap, false);
     boolean visible = CollectionUtil.getBool("visible", optionsMap, true);
@@ -428,16 +384,15 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
   }
 
   public void removeMarker(String id) {
-    UiThreadUtil.runOnUiThread(
-        () -> {
-          for (Marker m : markerList) {
-            if (m.getId().equals(id)) {
-              m.remove();
-              markerList.remove(m);
-              return;
-            }
-          }
-        });
+    UiThreadUtil.runOnUiThread(() -> {
+      for (Marker m : markerList) {
+        if (m.getId().equals(id)) {
+          m.remove();
+          markerList.remove(m);
+          return;
+        }
+      }
+    });
   }
 
   public void removePolyline(String id) {
@@ -499,8 +454,7 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     String imagePath = CollectionUtil.getString("imgPath", map);
     float width = Double.valueOf(CollectionUtil.getDouble("width", map, 0)).floatValue();
     float height = Double.valueOf(CollectionUtil.getDouble("height", map, 0)).floatValue();
-    float transparency =
-        Double.valueOf(CollectionUtil.getDouble("transparency", map, 0)).floatValue();
+    float transparency = Double.valueOf(CollectionUtil.getDouble("transparency", map, 0)).floatValue();
     boolean clickable = CollectionUtil.getBool("clickable", map, false);
     boolean visible = CollectionUtil.getBool("visible", map, true);
 
@@ -527,22 +481,17 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
   }
 
   public void setMapStyle(String url) {
-    Executors.newSingleThreadExecutor()
-        .execute(
-            () -> {
-              try {
-                style = fetchJsonFromUrl(url);
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-              requireActivity()
-                  .runOnUiThread(
-                      (Runnable)
-                          () -> {
-                            MapStyleOptions options = new MapStyleOptions(style);
-                            mGoogleMap.setMapStyle(options);
-                          });
-            });
+    Executors.newSingleThreadExecutor().execute(() -> {
+      try {
+        style = fetchJsonFromUrl(url);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      getActivity().runOnUiThread((Runnable) () -> {
+        MapStyleOptions options = new MapStyleOptions(style);
+        mGoogleMap.setMapStyle(options);
+      });
+    });
   }
 
   public String fetchJsonFromUrl(String urlString) throws IOException {
@@ -568,7 +517,10 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     }
   }
 
-  /** Moves the position of the camera to hover over Melbourne. */
+
+  /**
+   * Moves the position of the camera to hover over Melbourne.
+   */
   public void moveCamera(Map map) {
     LatLng latLng = ObjectTranslationUtil.getLatLngFromMap((Map) map.get("target"));
 
@@ -576,8 +528,7 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     float tilt = (float) CollectionUtil.getDouble("tilt", map, 0);
     float bearing = (float) CollectionUtil.getDouble("bearing", map, 0);
 
-    CameraPosition cameraPosition =
-        CameraPosition.builder().target(latLng).zoom(zoom).tilt(tilt).bearing(bearing).build();
+    CameraPosition cameraPosition = CameraPosition.builder().target(latLng).zoom(zoom).tilt(tilt).bearing(bearing).build();
 
     mGoogleMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
   }
@@ -651,9 +602,9 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
   public void setMyLocationEnabled(boolean isOn) {
     if (mGoogleMap != null) {
       if (ActivityCompat.checkSelfPermission(getActivity(), permission.ACCESS_FINE_LOCATION)
-              == PackageManager.PERMISSION_GRANTED
-          && ActivityCompat.checkSelfPermission(getActivity(), permission.ACCESS_COARSE_LOCATION)
-              == PackageManager.PERMISSION_GRANTED) {
+        == PackageManager.PERMISSION_GRANTED
+        && ActivityCompat.checkSelfPermission(getActivity(), permission.ACCESS_COARSE_LOCATION)
+        == PackageManager.PERMISSION_GRANTED) {
         mGoogleMap.setMyLocationEnabled(isOn);
       }
     }
@@ -665,16 +616,17 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     }
   }
 
-  /** Toggles whether the location marker is enabled. */
+  /**
+   * Toggles whether the location marker is enabled.
+   */
   public void setMyLocationButtonEnabled(boolean isOn) {
     if (mGoogleMap == null) {
       return;
     }
 
-    UiThreadUtil.runOnUiThread(
-        () -> {
-          mGoogleMap.getUiSettings().setMyLocationButtonEnabled(isOn);
-        });
+    UiThreadUtil.runOnUiThread(() -> {
+      mGoogleMap.getUiSettings().setMyLocationButtonEnabled(isOn);
+    });
   }
 
   @Override
@@ -689,18 +641,9 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     cleanup();
   }
 
-  public GoogleMap getGoogleMap() {
-    return mGoogleMap;
-  }
-
-  private void cleanup() {
-    removeOnRecenterButtonClickedListener(onRecenterButtonClickedListener);
-  }
-
   private void emitEvent(String eventName, @Nullable WritableMap data) {
     if (reactContext != null) {
-      EventDispatcher dispatcher =
-          UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewTag);
+      EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewTag);
 
       if (dispatcher != null) {
         int surfaceId = UIManagerHelper.getSurfaceId(reactContext);
@@ -709,12 +652,36 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     }
   }
 
+  public GoogleMap getGoogleMap() {
+    return mGoogleMap;
+  }
+
+  // Navigation related function of the IViewFragment interface. Not used in this class.
+  public void setNavigationUiEnabled(boolean enableNavigationUi) {}
+
+  public void setTripProgressBarEnabled(boolean enabled) {}
+
+  public void setSpeedometerEnabled(boolean enabled) {}
+
+  public void setSpeedLimitIconEnabled(boolean enabled) {}
+
+  public void setTrafficIncidentCardsEnabled(boolean enabled) {}
+
+  public void setEtaCardEnabled(boolean enabled) {}
+
+  public void setHeaderEnabled(boolean enabled) {}
+
+  public void setRecenterButtonEnabled(boolean enabled) {}
+
+  public void showRouteOverview() {}
+
+  private void cleanup() {}
+
   public class NavViewEvent extends Event<NavViewEvent> {
     private String eventName;
     private @Nullable WritableMap eventData;
 
-    public NavViewEvent(
-        int surfaceId, int viewTag, String eventName, @Nullable WritableMap eventData) {
+    public NavViewEvent(int surfaceId, int viewTag, String eventName, @Nullable WritableMap eventData) {
       super(surfaceId, viewTag);
       this.eventName = eventName;
       this.eventData = eventData;
@@ -734,3 +701,4 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
     }
   }
 }
+

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
@@ -65,7 +65,7 @@ import java.util.concurrent.Executors;
  * A fragment that displays a navigation view with a Google Map using SupportNavigationFragment.
  * This fragment's lifecycle is managed by NavViewManager.
  */
-public class NavViewFragment extends SupportNavigationFragment implements IViewFragment {
+public class NavViewFragment extends SupportNavigationFragment implements INavViewFragment {
   private static final String TAG = "NavViewFragment";
   private GoogleMap mGoogleMap;
   private StylingOptions mStylingOptions;

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
@@ -181,10 +181,6 @@ public class NavViewFragment extends SupportNavigationFragment implements IViewF
             });
   }
 
-  public boolean isNavigationSupportedOnMap() {
-    return true;
-  }
-
   public void applyStylingOptions() {
     if (mStylingOptions != null) {
       super.setStylingOptions(mStylingOptions);

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -34,6 +34,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+// NavViewManager is responsible for managing both the regular map fragment as well as the navigation map view fragment.
+//
 public class NavViewManager extends SimpleViewManager<FrameLayout> {
 
   public static final String REACT_CLASS = "NavViewManager";

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -14,6 +14,7 @@
 package com.google.android.react.navsdk;
 
 import static com.google.android.react.navsdk.Command.*;
+import static com.google.android.react.navsdk.EnumTranslationUtil.getFragmentTypeFromJsValue;
 
 import android.view.Choreographer;
 import android.view.View;
@@ -170,7 +171,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
     switch (Command.find(commandIdInt)) {
       case CREATE_FRAGMENT:
         Map<String, Object> stylingOptions = args.getMap(0).toHashMap();
-        int fragmentType = args.getInt(1);
+        CustomTypes.FragmentType fragmentType = getFragmentTypeFromJsValue(args.getInt(1));
         createFragment(root, stylingOptions, fragmentType);
         break;
       case DELETE_FRAGMENT:
@@ -327,7 +328,8 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
   }
 
   /** Replace your React Native view with a custom fragment */
-  public void createFragment(FrameLayout root, Map stylingOptions, int fragmentType) {
+  public void createFragment(
+      FrameLayout root, Map stylingOptions, CustomTypes.FragmentType fragmentType) {
     setupLayout(root);
 
     FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
@@ -335,7 +337,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
       int viewId = root.getId();
       Fragment fragment;
       // FragmentType 0 = MAP, 1 = NAVIGATION.
-      if (fragmentType == 0) {
+      if (fragmentType == CustomTypes.FragmentType.MAP) {
         MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
         fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(mapFragment));
         fragment = mapFragment;

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -40,7 +40,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
 
   private static NavViewManager instance;
 
-  private final HashMap<Integer, WeakReference<IViewFragment>> fragmentMap = new HashMap<>();
+  private final HashMap<Integer, WeakReference<IMapViewFragment>> fragmentMap = new HashMap<>();
 
   private ReactApplicationContext reactContext;
 
@@ -118,20 +118,31 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
     return map;
   }
 
-  public IViewFragment getFragmentForRoot(ViewGroup root) {
+  public INavViewFragment getNavFragmentForRoot(ViewGroup root) {
+    IMapViewFragment fragment = getFragmentForRoot(root);
+
+    // Check if the fragment is an INavigationViewFragment
+    if (fragment instanceof INavViewFragment) {
+      return (INavViewFragment) fragment;
+    } else {
+      throw new IllegalStateException("The fragment is not a nav view fragment");
+    }
+  }
+
+  public IMapViewFragment getFragmentForRoot(ViewGroup root) {
     int viewId = root.getId();
     return getFragmentForViewId(viewId);
   }
 
-  public IViewFragment getFragmentForViewId(int viewId) {
-    WeakReference<IViewFragment> weakReference = fragmentMap.get(viewId);
+  public IMapViewFragment getFragmentForViewId(int viewId) {
+    WeakReference<IMapViewFragment> weakReference = fragmentMap.get(viewId);
     if (weakReference == null || weakReference.get() == null) {
       throw new IllegalStateException("Fragment not found for the provided viewId.");
     }
     return weakReference.get();
   }
 
-  public IViewFragment getAnyFragment() {
+  public IMapViewFragment getAnyFragment() {
     if (fragmentMap.isEmpty()) {
       return null;
     }
@@ -140,7 +151,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
   }
 
   public void applyStylingOptions() {
-    for (WeakReference<IViewFragment> weakReference : fragmentMap.values()) {
+    for (WeakReference<IMapViewFragment> weakReference : fragmentMap.values()) {
       if (weakReference.get() != null) {
         weakReference.get().applyStylingOptions();
       }
@@ -163,7 +174,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
         try {
           int viewId = root.getId();
           FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
-          IViewFragment fragment = Objects.requireNonNull(fragmentMap.remove(viewId)).get();
+          IMapViewFragment fragment = Objects.requireNonNull(fragmentMap.remove(viewId)).get();
           activity
             .getSupportFragmentManager()
             .beginTransaction()
@@ -176,22 +187,22 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
         getFragmentForRoot(root).moveCamera(args.getMap(0).toHashMap());
         break;
       case SET_TRIP_PROGRESS_BAR_ENABLED:
-        getFragmentForRoot(root).setTripProgressBarEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setTripProgressBarEnabled(args.getBoolean(0));
         break;
       case SET_NAVIGATION_UI_ENABLED:
-        getFragmentForRoot(root).setNavigationUiEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setNavigationUiEnabled(args.getBoolean(0));
         break;
       case SET_FOLLOWING_PERSPECTIVE:
-        getFragmentForRoot(root).setFollowingPerspective(args.getInt(0));
+        getNavFragmentForRoot(root).setFollowingPerspective(args.getInt(0));
         break;
       case SET_NIGHT_MODE:
         getFragmentForRoot(root).setNightModeOption(args.getInt(0));
         break;
       case SET_SPEEDOMETER_ENABLED:
-        getFragmentForRoot(root).setSpeedometerEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setSpeedometerEnabled(args.getBoolean(0));
         break;
       case SET_SPEED_LIMIT_ICON_ENABLED:
-        getFragmentForRoot(root).setSpeedLimitIconEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setSpeedLimitIconEnabled(args.getBoolean(0));
         break;
       case SET_ZOOM_LEVEL:
         int level = args.getInt(0);
@@ -252,19 +263,19 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
         getFragmentForRoot(root).animateCamera(args.getMap(0).toHashMap());
         break;
       case SET_TRAFFIC_INCIDENT_CARDS_ENABLED:
-        getFragmentForRoot(root).setTrafficIncidentCardsEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setTrafficIncidentCardsEnabled(args.getBoolean(0));
         break;
       case SET_FOOTER_ENABLED:
-        getFragmentForRoot(root).setEtaCardEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setEtaCardEnabled(args.getBoolean(0));
         break;
       case SET_HEADER_ENABLED:
-        getFragmentForRoot(root).setHeaderEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setHeaderEnabled(args.getBoolean(0));
         break;
       case SET_RECENTER_BUTTON_ENABLED:
-        getFragmentForRoot(root).setRecenterButtonEnabled(args.getBoolean(0));
+        getNavFragmentForRoot(root).setRecenterButtonEnabled(args.getBoolean(0));
         break;
       case SHOW_ROUTE_OVERVIEW:
-        getFragmentForRoot(root).showRouteOverview();
+        getNavFragmentForRoot(root).showRouteOverview();
         break;
       case REMOVE_MARKER:
         getFragmentForRoot(root).removeMarker(args.getString(0));
@@ -326,7 +337,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
       // FragmentType 0 = MAP, 1 = NAVIGATION.
         if (fragmentType == 0) {
             MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
-            fragmentMap.put(viewId, new WeakReference<IViewFragment>(mapFragment));
+            fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(mapFragment));
             fragment = mapFragment;
 
             if (stylingOptions != null) {
@@ -334,7 +345,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
             }
         } else {
             NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
-            fragmentMap.put(viewId, new WeakReference<IViewFragment>(navFragment));
+            fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(navFragment));
             fragment = navFragment;
 
             if (stylingOptions != null) {
@@ -367,7 +378,7 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
 
   /** Layout all children properly */
   public void manuallyLayoutChildren(FrameLayout view) {
-    IViewFragment fragment = getFragmentForRoot(view);
+    IMapViewFragment fragment = getFragmentForRoot(view);
     if (fragment.isAdded()) {
       View childView = fragment.getView();
       if (childView != null) {

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -164,19 +164,11 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
           int viewId = root.getId();
           FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
           IViewFragment fragment = Objects.requireNonNull(fragmentMap.remove(viewId)).get();
-          if (fragment.isNavigationSupportedOnMap()) {
-            activity
-              .getSupportFragmentManager()
-              .beginTransaction()
-              .remove((Fragment) fragment)
-              .commitNowAllowingStateLoss();
-          } else {
-            activity
-              .getFragmentManager()
-              .beginTransaction()
-              .remove((android.app.Fragment) fragment)
-              .commit(); // TODO: Check if commitNowAllowingStateLoss() could be used.
-          }
+          activity
+            .getSupportFragmentManager()
+            .beginTransaction()
+            .remove((Fragment) fragment)
+            .commitNowAllowingStateLoss();
         } catch (Exception ignored) {
         }
         break;
@@ -330,31 +322,28 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
     FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
     if (activity != null) {
       int viewId = root.getId();
+      Fragment fragment;
       if (isNavigationEnabled) {
-        NavViewFragment fragment = new NavViewFragment(reactContext, root.getId());
-        fragmentMap.put(viewId, new WeakReference<IViewFragment>(fragment));
+        NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
+        fragmentMap.put(viewId, new WeakReference<IViewFragment>(navFragment));
+        fragment = navFragment;
 
         if (stylingOptions != null) {
-          fragment.setStylingOptions(stylingOptions);
+          navFragment.setStylingOptions(stylingOptions);
         }
-
-        activity.getSupportFragmentManager()
-          .beginTransaction()
-          .replace(viewId, fragment, String.valueOf(viewId))
-          .commit();
       } else {
-        MapViewFragment fragment = new MapViewFragment(reactContext, root.getId());
-        fragmentMap.put(viewId, new WeakReference<IViewFragment>(fragment));
+        MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
+        fragmentMap.put(viewId, new WeakReference<IViewFragment>(mapFragment));
+        fragment = mapFragment;
 
         if (stylingOptions != null) {
-          fragment.setStylingOptions(stylingOptions);
+          mapFragment.setStylingOptions(stylingOptions);
         }
-
-        activity.getFragmentManager()
-          .beginTransaction()
-          .replace(viewId, fragment, String.valueOf(viewId))
-          .commit();
       }
+      activity.getSupportFragmentManager()
+        .beginTransaction()
+        .replace(viewId, fragment, String.valueOf(viewId))
+        .commit();
     }
   }
 

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -34,7 +34,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-// NavViewManager is responsible for managing both the regular map fragment as well as the navigation map view fragment.
+// NavViewManager is responsible for managing both the regular map fragment as well as the
+// navigation map view fragment.
 //
 public class NavViewManager extends SimpleViewManager<FrameLayout> {
 
@@ -178,10 +179,10 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
           FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
           IMapViewFragment fragment = Objects.requireNonNull(fragmentMap.remove(viewId)).get();
           activity
-            .getSupportFragmentManager()
-            .beginTransaction()
-            .remove((Fragment) fragment)
-            .commitNowAllowingStateLoss();
+              .getSupportFragmentManager()
+              .beginTransaction()
+              .remove((Fragment) fragment)
+              .commitNowAllowingStateLoss();
         } catch (Exception ignored) {
         }
         break;
@@ -325,11 +326,8 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
     return (Map) eventTypeConstants;
   }
 
-  /**
-   * Replace your React Native view with a custom fragment
-   */
-  public void createFragment(
-    FrameLayout root, Map stylingOptions, int fragmentType) {
+  /** Replace your React Native view with a custom fragment */
+  public void createFragment(FrameLayout root, Map stylingOptions, int fragmentType) {
     setupLayout(root);
 
     FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
@@ -338,26 +336,27 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
       Fragment fragment;
       // FragmentType 0 = MAP, 1 = NAVIGATION.
       if (fragmentType == 0) {
-          MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
-          fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(mapFragment));
-          fragment = mapFragment;
+        MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
+        fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(mapFragment));
+        fragment = mapFragment;
 
-          if (stylingOptions != null) {
-              mapFragment.setStylingOptions(stylingOptions);
-          }
+        if (stylingOptions != null) {
+          mapFragment.setStylingOptions(stylingOptions);
+        }
       } else {
-          NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
-          fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(navFragment));
-          fragment = navFragment;
+        NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
+        fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(navFragment));
+        fragment = navFragment;
 
-          if (stylingOptions != null) {
-              navFragment.setStylingOptions(stylingOptions);
-          }
+        if (stylingOptions != null) {
+          navFragment.setStylingOptions(stylingOptions);
+        }
       }
-      activity.getSupportFragmentManager()
-        .beginTransaction()
-        .replace(viewId, fragment, String.valueOf(viewId))
-        .commit();
+      activity
+          .getSupportFragmentManager()
+          .beginTransaction()
+          .replace(viewId, fragment, String.valueOf(viewId))
+          .commit();
     }
   }
 

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -337,23 +337,23 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
       int viewId = root.getId();
       Fragment fragment;
       // FragmentType 0 = MAP, 1 = NAVIGATION.
-        if (fragmentType == 0) {
-            MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
-            fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(mapFragment));
-            fragment = mapFragment;
+      if (fragmentType == 0) {
+          MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
+          fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(mapFragment));
+          fragment = mapFragment;
 
-            if (stylingOptions != null) {
-                mapFragment.setStylingOptions(stylingOptions);
-            }
-        } else {
-            NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
-            fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(navFragment));
-            fragment = navFragment;
+          if (stylingOptions != null) {
+              mapFragment.setStylingOptions(stylingOptions);
+          }
+      } else {
+          NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
+          fragmentMap.put(viewId, new WeakReference<IMapViewFragment>(navFragment));
+          fragment = navFragment;
 
-            if (stylingOptions != null) {
-                navFragment.setStylingOptions(stylingOptions);
-            }
-        }
+          if (stylingOptions != null) {
+              navFragment.setStylingOptions(stylingOptions);
+          }
+      }
       activity.getSupportFragmentManager()
         .beginTransaction()
         .replace(viewId, fragment, String.valueOf(viewId))

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -156,8 +156,8 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
     switch (Command.find(commandIdInt)) {
       case CREATE_FRAGMENT:
         Map<String, Object> stylingOptions = args.getMap(0).toHashMap();
-        Boolean isNavigationEnabled = args.getBoolean(1);
-        createFragment(root, stylingOptions, isNavigationEnabled);
+        int fragmentType = args.getInt(1);
+        createFragment(root, stylingOptions, fragmentType);
         break;
       case DELETE_FRAGMENT:
         try {
@@ -316,30 +316,31 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
    * Replace your React Native view with a custom fragment
    */
   public void createFragment(
-    FrameLayout root, Map stylingOptions, Boolean isNavigationEnabled) {
+    FrameLayout root, Map stylingOptions, int fragmentType) {
     setupLayout(root);
 
     FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
     if (activity != null) {
       int viewId = root.getId();
       Fragment fragment;
-      if (isNavigationEnabled) {
-        NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
-        fragmentMap.put(viewId, new WeakReference<IViewFragment>(navFragment));
-        fragment = navFragment;
+      // FragmentType 0 = MAP, 1 = NAVIGATION.
+        if (fragmentType == 0) {
+            MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
+            fragmentMap.put(viewId, new WeakReference<IViewFragment>(mapFragment));
+            fragment = mapFragment;
 
-        if (stylingOptions != null) {
-          navFragment.setStylingOptions(stylingOptions);
-        }
-      } else {
-        MapViewFragment mapFragment = new MapViewFragment(reactContext, root.getId());
-        fragmentMap.put(viewId, new WeakReference<IViewFragment>(mapFragment));
-        fragment = mapFragment;
+            if (stylingOptions != null) {
+                mapFragment.setStylingOptions(stylingOptions);
+            }
+        } else {
+            NavViewFragment navFragment = new NavViewFragment(reactContext, root.getId());
+            fragmentMap.put(viewId, new WeakReference<IViewFragment>(navFragment));
+            fragment = navFragment;
 
-        if (stylingOptions != null) {
-          mapFragment.setStylingOptions(stylingOptions);
+            if (stylingOptions != null) {
+                navFragment.setStylingOptions(stylingOptions);
+            }
         }
-      }
       activity.getSupportFragmentManager()
         .beginTransaction()
         .replace(viewId, fragment, String.valueOf(viewId))

--- a/example/src/MultipleMapsScreen.tsx
+++ b/example/src/MultipleMapsScreen.tsx
@@ -40,6 +40,7 @@ import {
 import usePermissions from './checkPermissions';
 import OverlayModal from './overlayModal';
 import { NavigationView } from '../../src/navigation/navigationView/navigationView';
+import MapView from '../../src/maps/mapView/mapView';
 
 const showSnackbar = (text: string, duration = Snackbar.LENGTH_SHORT) => {
   Snackbar.show({ text, duration });
@@ -60,8 +61,6 @@ const MultipleMapsScreen = () => {
   const [mapViewController2, setMapViewController2] =
     useState<MapViewController | null>(null);
   const [navigationViewController1, setNavigationViewController1] =
-    useState<NavigationViewController | null>(null);
-  const [navigationViewController2, setNavigationViewController2] =
     useState<NavigationViewController | null>(null);
   const [navigationInitialized, setNavigationInitialized] = useState(false);
   const { navigationController, addListeners, removeListeners } =
@@ -92,22 +91,17 @@ const MultipleMapsScreen = () => {
   }, []);
 
   const onNavigationReady = useCallback(async () => {
-    if (
-      navigationViewController1 != null &&
-      navigationViewController2 != null
-    ) {
+    if (navigationViewController1 != null) {
       await navigationViewController1.setNavigationUIEnabled(true);
-      await navigationViewController2.setNavigationUIEnabled(true);
       console.log('onNavigationReady');
       setNavigationInitialized(true);
     }
-  }, [navigationViewController1, navigationViewController2]);
+  }, [navigationViewController1]);
 
   const onNavigationDispose = useCallback(async () => {
     await navigationViewController1?.setNavigationUIEnabled(false);
-    await navigationViewController2?.setNavigationUIEnabled(false);
     setNavigationInitialized(false);
-  }, [navigationViewController1, navigationViewController2]);
+  }, [navigationViewController1]);
 
   const onNavigationInitError = useCallback(
     (errorCode: NavigationInitErrorCode) => {
@@ -346,20 +340,9 @@ const MultipleMapsScreen = () => {
         onNavigationViewControllerCreated={setNavigationViewController1}
       />
 
-      <NavigationView
-        androidStylingOptions={{
-          primaryDayModeThemeColor: '#34eba8',
-          headerDistanceValueTextColor: '#76b5c5',
-          headerInstructionsFirstRowTextSize: '20f',
-        }}
-        iOSStylingOptions={{
-          navigationHeaderPrimaryBackgroundColor: '#34eba8',
-          navigationHeaderDistanceValueTextColor: '#76b5c5',
-        }}
-        navigationViewCallbacks={navigationViewCallbacks}
+      <MapView
         mapViewCallbacks={mapViewCallbacks2}
         onMapViewControllerCreated={setMapViewController2}
-        onNavigationViewControllerCreated={setNavigationViewController2}
       />
 
       {navigationViewController1 != null &&

--- a/example/src/MultipleMapsScreen.tsx
+++ b/example/src/MultipleMapsScreen.tsx
@@ -36,11 +36,11 @@ import {
   type LatLng,
   type NavigationCallbacks,
   useNavigation,
+  MapView,
+  NavigationView,
 } from '@googlemaps/react-native-navigation-sdk';
 import usePermissions from './checkPermissions';
 import OverlayModal from './overlayModal';
-import { NavigationView } from '../../src/navigation/navigationView/navigationView';
-import MapView from '../../src/maps/mapView/mapView';
 
 const showSnackbar = (text: string, duration = Snackbar.LENGTH_SHORT) => {
   Snackbar.show({ text, duration });

--- a/ios/react-native-navigation-sdk/CustomTypes.h
+++ b/ios/react-native-navigation-sdk/CustomTypes.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CustomTypes_h
+#define CustomTypes_h
+
+typedef NS_ENUM(NSInteger, FragmentType) {
+  MAP,
+  NAVIGATION,
+};
+
+#endif /* CustomTypes_h */

--- a/ios/react-native-navigation-sdk/NavView.h
+++ b/ios/react-native-navigation-sdk/NavView.h
@@ -33,7 +33,7 @@
 @property(nonatomic, copy) RCTDirectEventBlock onCircleClick;
 @property(nonatomic, copy) RCTDirectEventBlock onGroundOverlayClick;
 
-- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions;
+- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions isNavigationEnabled:(BOOL)isNavigationEnabled;
 - (NavViewController *)getViewController;
 
 @end

--- a/ios/react-native-navigation-sdk/NavView.h
+++ b/ios/react-native-navigation-sdk/NavView.h
@@ -17,6 +17,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTComponent.h>
 #import <React/RCTViewManager.h>
+#import "CustomTypes.h"
 #import "INavigationViewCallback.h"
 
 @class NavViewController;
@@ -34,7 +35,7 @@
 @property(nonatomic, copy) RCTDirectEventBlock onGroundOverlayClick;
 
 - (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions
-                                                     fragmentType:(NSInteger)fragmentType;
+                                                     fragmentType:(FragmentType)fragmentType;
 - (NavViewController *)getViewController;
 
 @end

--- a/ios/react-native-navigation-sdk/NavView.h
+++ b/ios/react-native-navigation-sdk/NavView.h
@@ -33,7 +33,7 @@
 @property(nonatomic, copy) RCTDirectEventBlock onCircleClick;
 @property(nonatomic, copy) RCTDirectEventBlock onGroundOverlayClick;
 
-- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions isNavigationEnabled:(BOOL)isNavigationEnabled;
+- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions fragmentType:(NSInteger)fragmentType;
 - (NavViewController *)getViewController;
 
 @end

--- a/ios/react-native-navigation-sdk/NavView.h
+++ b/ios/react-native-navigation-sdk/NavView.h
@@ -33,7 +33,8 @@
 @property(nonatomic, copy) RCTDirectEventBlock onCircleClick;
 @property(nonatomic, copy) RCTDirectEventBlock onGroundOverlayClick;
 
-- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions fragmentType:(NSInteger)fragmentType;
+- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions
+                                                     fragmentType:(NSInteger)fragmentType;
 - (NavViewController *)getViewController;
 
 @end

--- a/ios/react-native-navigation-sdk/NavView.m
+++ b/ios/react-native-navigation-sdk/NavView.m
@@ -36,8 +36,9 @@
   }
 }
 
-- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions {
+- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions isNavigationEnabled:(BOOL)isNavigationEnabled {
   _viewController = [[NavViewController alloc] init];
+  _viewController.isNavigationEnabled = isNavigationEnabled;
   // Test if styling options is not nil
   if (stylingOptions != nil && [stylingOptions count] > 0) {
     [_viewController setStylingOptions:stylingOptions];

--- a/ios/react-native-navigation-sdk/NavView.m
+++ b/ios/react-native-navigation-sdk/NavView.m
@@ -36,9 +36,10 @@
   }
 }
 
-- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions isNavigationEnabled:(BOOL)isNavigationEnabled {
+- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions fragmentType:(NSInteger)fragmentType {
   _viewController = [[NavViewController alloc] init];
-  _viewController.isNavigationEnabled = isNavigationEnabled;
+  // FragmentType 0 = MAP, 1 = NAVIGATION.
+  _viewController.isNavigationEnabled = fragmentType == 1;
   // Test if styling options is not nil
   if (stylingOptions != nil && [stylingOptions count] > 0) {
     [_viewController setStylingOptions:stylingOptions];

--- a/ios/react-native-navigation-sdk/NavView.m
+++ b/ios/react-native-navigation-sdk/NavView.m
@@ -37,10 +37,10 @@
 }
 
 - (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions
-                                                     fragmentType:(NSInteger)fragmentType {
+                                                     fragmentType:(FragmentType)fragmentType {
   _viewController = [[NavViewController alloc] init];
   // FragmentType 0 = MAP, 1 = NAVIGATION.
-  _viewController.isNavigationEnabled = fragmentType == 1;
+  _viewController.isNavigationEnabled = fragmentType == NAVIGATION;
   // Test if styling options is not nil
   if (stylingOptions != nil && [stylingOptions count] > 0) {
     [_viewController setStylingOptions:stylingOptions];

--- a/ios/react-native-navigation-sdk/NavView.m
+++ b/ios/react-native-navigation-sdk/NavView.m
@@ -36,7 +36,8 @@
   }
 }
 
-- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions fragmentType:(NSInteger)fragmentType {
+- (NavViewController *)initializeViewControllerWithStylingOptions:(NSDictionary *)stylingOptions
+                                                     fragmentType:(NSInteger)fragmentType {
   _viewController = [[NavViewController alloc] init];
   // FragmentType 0 = MAP, 1 = NAVIGATION.
   _viewController.isNavigationEnabled = fragmentType == 1;

--- a/ios/react-native-navigation-sdk/NavViewController.h
+++ b/ios/react-native-navigation-sdk/NavViewController.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NavViewController : UIViewController <GMSMapViewNavigationUIDelegate, GMSMapViewDelegate>
 
 @property(weak, nonatomic) id<INavigationViewCallback> callbacks;
+@property(nonatomic, assign) BOOL isNavigationEnabled;
 typedef void (^RouteStatusCallback)(GMSRouteStatus routeStatus);
 typedef void (^OnStringResult)(NSString *result);
 typedef void (^OnBooleanResult)(BOOL result);

--- a/ios/react-native-navigation-sdk/NavViewController.m
+++ b/ios/react-native-navigation-sdk/NavViewController.m
@@ -168,10 +168,7 @@
 }
 
 - (void)setZoomLevel:(nonnull NSNumber *)level {
-  _mapView.camera =
-      [GMSMutableCameraPosition cameraWithLatitude:_mapView.myLocation.coordinate.latitude
-                                         longitude:_mapView.myLocation.coordinate.longitude
-                                              zoom:[level floatValue]];
+  [_mapView animateToZoom:[level floatValue]];
 }
 
 - (void)setNavigationUIEnabled:(BOOL)isEnabled {

--- a/ios/react-native-navigation-sdk/NavViewController.m
+++ b/ios/react-native-navigation-sdk/NavViewController.m
@@ -280,6 +280,9 @@
 #pragma mark - View Controller functions
 
 - (BOOL)attachToNavigationSession:(GMSNavigationSession *)session {
+  if (!_isNavigationEnabled) {
+    return NO;
+  }
   BOOL result = [_mapView enableNavigationWithSession:session];
   _mapView.navigationUIDelegate = self;
   [self applyStylingOptions];

--- a/ios/react-native-navigation-sdk/RCTNavViewManager.m
+++ b/ios/react-native-navigation-sdk/RCTNavViewManager.m
@@ -21,7 +21,8 @@
 #import "NavViewModule.h"
 #import "ObjectTranslationUtil.h"
 
-// RCTNavViewManager is responsible for managing both the regular map fragment as well as the navigation map view fragment.
+// RCTNavViewManager is responsible for managing both the regular map fragment as well as the
+// navigation map view fragment.
 //
 @implementation RCTNavViewManager
 static NSMutableDictionary<NSNumber *, NavViewController *> *_viewControllers;
@@ -76,19 +77,19 @@ RCT_EXPORT_METHOD(createFragment
                   : (nonnull NSNumber *)reactTag stylingOptions
                   : (NSDictionary *)stylingOptions fragmentType
                   : (NSInteger)fragmentType) {
-  [self.bridge.uiManager
-      addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        NavView *view = (NavView *)viewRegistry[reactTag];
-        if (!view || ![view isKindOfClass:[NavView class]]) {
-          RCTLogError(@"Cannot find NativeView with tag #%@", reactTag);
-          return;
-        }
+  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager,
+                                      NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    NavView *view = (NavView *)viewRegistry[reactTag];
+    if (!view || ![view isKindOfClass:[NavView class]]) {
+      RCTLogError(@"Cannot find NativeView with tag #%@", reactTag);
+      return;
+    }
 
-        NavViewController *viewController =
-            [view initializeViewControllerWithStylingOptions:stylingOptions fragmentType:fragmentType];
+    NavViewController *viewController =
+        [view initializeViewControllerWithStylingOptions:stylingOptions fragmentType:fragmentType];
 
-        [self registerViewController:viewController forTag:reactTag];
-      }];
+    [self registerViewController:viewController forTag:reactTag];
+  }];
 }
 
 RCT_EXPORT_METHOD(deleteFragment : (nonnull NSNumber *)reactTag) {

--- a/ios/react-native-navigation-sdk/RCTNavViewManager.m
+++ b/ios/react-native-navigation-sdk/RCTNavViewManager.m
@@ -72,7 +72,8 @@ RCT_EXPORT_VIEW_PROPERTY(onGroundOverlayClick, RCTDirectEventBlock);
 
 RCT_EXPORT_METHOD(createFragment
                   : (nonnull NSNumber *)reactTag stylingOptions
-                  : (NSDictionary *)stylingOptions) {
+                  : (NSDictionary *)stylingOptions isNavigationEnabled
+                  : (BOOL)isNavigationEnabled) {
   [self.bridge.uiManager
       addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
         NavView *view = (NavView *)viewRegistry[reactTag];
@@ -82,7 +83,7 @@ RCT_EXPORT_METHOD(createFragment
         }
 
         NavViewController *viewController =
-            [view initializeViewControllerWithStylingOptions:stylingOptions];
+            [view initializeViewControllerWithStylingOptions:stylingOptions isNavigationEnabled:isNavigationEnabled];
 
         [self registerViewController:viewController forTag:reactTag];
       }];

--- a/ios/react-native-navigation-sdk/RCTNavViewManager.m
+++ b/ios/react-native-navigation-sdk/RCTNavViewManager.m
@@ -21,6 +21,8 @@
 #import "NavViewModule.h"
 #import "ObjectTranslationUtil.h"
 
+// RCTNavViewManager is responsible for managing both the regular map fragment as well as the navigation map view fragment.
+//
 @implementation RCTNavViewManager
 static NSMutableDictionary<NSNumber *, NavViewController *> *_viewControllers;
 static NavViewModule *_navViewModule;

--- a/ios/react-native-navigation-sdk/RCTNavViewManager.m
+++ b/ios/react-native-navigation-sdk/RCTNavViewManager.m
@@ -72,8 +72,8 @@ RCT_EXPORT_VIEW_PROPERTY(onGroundOverlayClick, RCTDirectEventBlock);
 
 RCT_EXPORT_METHOD(createFragment
                   : (nonnull NSNumber *)reactTag stylingOptions
-                  : (NSDictionary *)stylingOptions isNavigationEnabled
-                  : (BOOL)isNavigationEnabled) {
+                  : (NSDictionary *)stylingOptions fragmentType
+                  : (NSInteger)fragmentType) {
   [self.bridge.uiManager
       addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
         NavView *view = (NavView *)viewRegistry[reactTag];
@@ -83,7 +83,7 @@ RCT_EXPORT_METHOD(createFragment
         }
 
         NavViewController *viewController =
-            [view initializeViewControllerWithStylingOptions:stylingOptions isNavigationEnabled:isNavigationEnabled];
+            [view initializeViewControllerWithStylingOptions:stylingOptions fragmentType:fragmentType];
 
         [self registerViewController:viewController forTag:reactTag];
       }];

--- a/ios/react-native-navigation-sdk/RCTNavViewManager.m
+++ b/ios/react-native-navigation-sdk/RCTNavViewManager.m
@@ -16,6 +16,7 @@
 
 #import "RCTNavViewManager.h"
 #import <React/RCTUIManager.h>
+#import "CustomTypes.h"
 #import "NavView.h"
 #import "NavViewController.h"
 #import "NavViewModule.h"

--- a/src/maps/mapView/index.ts
+++ b/src/maps/mapView/index.ts
@@ -16,3 +16,4 @@
 
 export * from './types';
 export * from './mapViewController';
+export * from './mapView';

--- a/src/maps/mapView/mapView.tsx
+++ b/src/maps/mapView/mapView.tsx
@@ -15,34 +15,28 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Platform, StyleSheet, View, findNodeHandle } from 'react-native';
+import { StyleSheet, View, findNodeHandle } from 'react-native';
 import {
   NavViewManager,
   sendCommand,
   commands,
   type LatLng,
 } from '../../shared';
-import { getNavigationViewController } from './navigationViewController';
-import type { NavigationViewProps } from './types';
 import {
   getMapViewController,
   type Circle,
   type GroundOverlay,
+  type MapViewProps,
   type Marker,
   type Polygon,
   type Polyline,
-} from '../../maps';
+} from '..';
 
-export const NavigationView = (props: NavigationViewProps) => {
+export const MapView = (props: MapViewProps) => {
   const mapViewRef = useRef<any>(null);
   const [viewId, setViewId] = useState<number | null>(null);
 
-  const {
-    androidStylingOptions,
-    iOSStylingOptions,
-    onNavigationViewControllerCreated,
-    onMapViewControllerCreated,
-  } = props;
+  const { onMapViewControllerCreated } = props;
 
   /**
    * @param {any} _ref - The reference to the NavViewManager component.
@@ -61,12 +55,9 @@ export const NavigationView = (props: NavigationViewProps) => {
     if (viewId !== _viewId) {
       setViewId(_viewId);
 
-      const isNavigationEnabled = true;
+      const isNavigationEnabled = false;
 
-      const stylingOptions =
-        (Platform.OS === 'android'
-          ? androidStylingOptions
-          : iOSStylingOptions) || {};
+      const stylingOptions = {};
 
       const args = [stylingOptions, isNavigationEnabled];
 
@@ -74,16 +65,9 @@ export const NavigationView = (props: NavigationViewProps) => {
         sendCommand(_viewId, commands.createFragment, args);
       });
 
-      onNavigationViewControllerCreated(getNavigationViewController(_viewId));
       onMapViewControllerCreated(getMapViewController(_viewId));
     }
-  }, [
-    androidStylingOptions,
-    iOSStylingOptions,
-    onMapViewControllerCreated,
-    onNavigationViewControllerCreated,
-    viewId,
-  ]);
+  }, [onMapViewControllerCreated, viewId]);
 
   const onMapClick = useCallback(
     ({ nativeEvent: latlng }: { nativeEvent: LatLng }) => {
@@ -138,10 +122,6 @@ export const NavigationView = (props: NavigationViewProps) => {
     [props.mapViewCallbacks]
   );
 
-  const onRecenterButtonClick = useCallback(() => {
-    props.navigationViewCallbacks?.onRecenterButtonClick?.();
-  }, [props.navigationViewCallbacks]);
-
   return (
     <View style={props.style ?? styles.defaultStyle}>
       <NavViewManager
@@ -155,7 +135,6 @@ export const NavigationView = (props: NavigationViewProps) => {
         onCircleClick={onCircleClick}
         onGroundOverlayClick={onGroundOverlayClick}
         onMarkerInfoWindowTapped={onMarkerInfoWindowTapped}
-        onRecenterButtonClick={onRecenterButtonClick}
       />
     </View>
   );
@@ -167,4 +146,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default NavigationView;
+export default MapView;

--- a/src/maps/mapView/mapView.tsx
+++ b/src/maps/mapView/mapView.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../shared';
 import {
   getMapViewController,
+  FragmentType,
   type Circle,
   type GroundOverlay,
   type MapViewProps,
@@ -55,11 +56,9 @@ export const MapView = (props: MapViewProps) => {
     if (viewId !== _viewId) {
       setViewId(_viewId);
 
-      const isNavigationEnabled = false;
-
       const stylingOptions = {};
 
-      const args = [stylingOptions, isNavigationEnabled];
+      const args = [stylingOptions, FragmentType.MAP];
 
       setTimeout(() => {
         sendCommand(_viewId, commands.createFragment, args);

--- a/src/maps/mapView/types.ts
+++ b/src/maps/mapView/types.ts
@@ -124,6 +124,16 @@ export enum MapType {
 }
 
 /**
+ * Defines the type of the map fragment.
+ */
+export enum FragmentType {
+  /** Regular Google map view without navigation */
+  MAP = 0,
+  /** Google map view with navigation */
+  NAVIGATION,
+}
+
+/**
  * `MapViewProps` interface provides a set of method definitions
  * for managing map events and debug information.
  */

--- a/src/maps/types.ts
+++ b/src/maps/types.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import type { StyleProp, ViewStyle } from 'react-native';
 import type { LatLng } from '../shared/types';
+import type { MapViewCallbacks, MapViewController } from './mapView/types';
 
 /**
  * An immutable class that aggregates all camera position parameters such as
@@ -156,4 +158,15 @@ export interface UISettings {
   isZoomControlsEnabled: boolean;
   /** Defines zoom gestures are enabled/disabled on the GoogleMap. */
   isZoomGesturesEnabled: boolean;
+}
+
+/**
+ * `MapViewProps` interface provides methods focused on managing map events and state changes.
+ */
+export interface MapViewProps {
+  readonly mapViewCallbacks?: MapViewCallbacks;
+
+  readonly style?: StyleProp<ViewStyle> | undefined;
+
+  onMapViewControllerCreated(mapViewController: MapViewController): void;
 }

--- a/src/navigation/navigationView/navigationView.tsx
+++ b/src/navigation/navigationView/navigationView.tsx
@@ -26,6 +26,7 @@ import { getNavigationViewController } from './navigationViewController';
 import type { NavigationViewProps } from './types';
 import {
   getMapViewController,
+  FragmentType,
   type Circle,
   type GroundOverlay,
   type Marker,
@@ -61,14 +62,12 @@ export const NavigationView = (props: NavigationViewProps) => {
     if (viewId !== _viewId) {
       setViewId(_viewId);
 
-      const isNavigationEnabled = true;
-
       const stylingOptions =
         (Platform.OS === 'android'
           ? androidStylingOptions
           : iOSStylingOptions) || {};
 
-      const args = [stylingOptions, isNavigationEnabled];
+      const args = [stylingOptions, FragmentType.NAVIGATION];
 
       setTimeout(() => {
         sendCommand(_viewId, commands.createFragment, args);

--- a/src/shared/viewManager.ts
+++ b/src/shared/viewManager.ts
@@ -26,7 +26,6 @@ import type { LatLng } from '.';
 import type { Circle, GroundOverlay, Marker, Polygon, Polyline } from '../maps';
 
 // NavViewManager is responsible for managing both the regular map fragment as well as the navigation map view fragment.
-//
 export const viewManagerName =
   Platform.OS === 'android' ? 'NavViewManager' : 'RCTNavView';
 

--- a/src/shared/viewManager.ts
+++ b/src/shared/viewManager.ts
@@ -25,6 +25,8 @@ import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTyp
 import type { LatLng } from '.';
 import type { Circle, GroundOverlay, Marker, Polygon, Polyline } from '../maps';
 
+// NavViewManager is responsible for managing both the regular map fragment as well as the navigation map view fragment.
+//
 export const viewManagerName =
   Platform.OS === 'android' ? 'NavViewManager' : 'RCTNavView';
 


### PR DESCRIPTION
Resolves #254
Resolves #104
Fixes #234

- Separate MapView component has been implemented, allowing the classic map to be displayed without any effects from an ongoing or initialized navigation session.
- If map without navigation is used
  - On Android a new fragment type `SupportMapFragment` is created instead of `SupportNavigationFragment`.
  - On iOS the same view will be used, but the navigation session will not be attached to the map
- Fixed map zooming on iOS. Previously it always zoomed into/out of user's location.
>
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR