### PR TITLE
chore: revert b182d14 and fix registry url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://wombat-dressing-room.appspot.com/@googlemaps/react-native-navigation-sdk/_ns'
 
       - name: Publish
         # npm publish will trigger the build via the prepack hook
-        run: npm publish --access public --registry https://wombat-dressing-room.appspot.com
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_WOMBOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ This repository contains a React Native plugin that provides a [Google Navigatio
 | **Minimum mobile OS supported** | SDK 23+ | iOS 14.0+ |
 
 * A React Native project
-- A Google Cloud project with a Mobility solution enabled, such as On-Demand Rides and Deliveries or Last Mile Fleet Solution. This requires you to Contact Sales as described in the [Mobility services documentation](https://developers.google.com/maps/documentation/transportation-logistics/mobility).
-- In that Google Cloud project,  these four products also need to be enabled depending on the target(s) of your React Native app:
-  - [Maps SDK for Android](https://developers.google.com/maps/documentation/android-sdk/cloud-setup#enabling-apis)
-  - [Navigation SDK for Android](https://developers.google.com/maps/documentation/navigation/android-sdk/set-up-project)
-  - [Maps SDK for iOS](https://developers.google.com/maps/documentation/ios-sdk/cloud-setup#enabling-apis)
-  - [Navigation SDK for iOS](https://developers.google.com/maps/documentation/navigation/ios-sdk/config)
+* A Google Cloud project
+  *  If you are a Mobility Services developer, you must contact Sales as described in [Mobility services documentation](https://developers.google.com/maps/documentation/transportation-logistics/mobility).
+  *  If you are not a Mobility Services developer, refer to [Setup Google Cloud Project](https://developers.google.com/maps/documentation/navigation/android-sdk/cloud-setup) for instructions.
 * An [API key](https://console.cloud.google.com/google/maps-apis/credentials) from the project above
+  * The API key must be configured for both Android and iOS. Refer to [Android Using Api Keys](https://developers.google.com/maps/documentation/navigation/android-sdk/get-api-key) and [iOS Using Api Keys](https://developers.google.com/maps/documentation/navigation/ios-sdk/get-api-key) respectively for instructions.
 * If targeting Android, [Google Play Services](https://developers.google.com/android/guides/overview) installed and enabled
 * [Attributions and licensing text](https://developers.google.com/maps/documentation/navigation/android-sdk/set-up-project#include_the_required_attributions_in_your_app) added to your app
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "navsdk"
   ],
   "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
+    "registry": "https://wombat-dressing-room.appspot.com/@googlemaps/react-native-navigation-sdk/_ns"
   },
   "scripts": {
     "example": "yarn workspace react-native-navigation-sdk-sample",


### PR DESCRIPTION
The publish workflow is failling auth; this attempts to fix it by using a per-package registry URL.