### PR TITLE
fix: enable remaining time distance listener on ios

### DIFF
--- a/ios/react-native-navigation-sdk/NavModule.m
+++ b/ios/react-native-navigation-sdk/NavModule.m
@@ -99,8 +99,6 @@ RCT_EXPORT_MODULE(NavModule);
   if (self->_session.navigator) {
     [self->_session.navigator addListener:self];
     self->_session.navigator.stopGuidanceAtArrival = NO;
-    self->_session.navigator.timeUpdateThreshold = DBL_MAX;
-    self->_session.navigator.distanceUpdateThreshold = CLLocationDistanceMax;
   }
 
   [self->_session.roadSnappedLocationProvider addListener:self];


### PR DESCRIPTION
Fixes #273

Removes min thresholds preventing onRemainingTimeOrDistanceChanged from triggering on iOS.
 
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR