### PR TITLE
ci: reduce duplicate build steps on release-please release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
-    uses: ./.github/workflows/ci.yml
-
   publish:
     runs-on: ubuntu-latest
-    needs: build-and-test
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Release please publish process runs tests and builds tasks multiple times, as this step was included in both, release-please.yml and publish.yml

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR