### PR TITLE
chore: Remove Caio/arturo from assign_issues list in blunderbuss

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -14,8 +14,7 @@
 
 assign_issues:
   - jokerttu
-  - ArturoSalazarB16
-  - caio1985
+  - illuminati1911
 assign_prs:
   - jokerttu
   - ArturoSalazarB16


### PR DESCRIPTION
chore: Remove Caio/arturo from assign_issues list in blunderbuss