### PR TITLE
docs: document onTrafficUpdated listener as Android only

### DIFF
--- a/src/navigation/navigation/types.ts
+++ b/src/navigation/navigation/types.ts
@@ -177,7 +177,7 @@ export interface NavigationCallbacks {
   onReroutingRequestedByOffRoute?(): void;
 
   /**
-   * Callback function invoked when traffic data is updated.
+   * Callback function invoked when traffic data is updated (Android only).
    */
   onTrafficUpdated?(): void;
 


### PR DESCRIPTION
Marked onTrafficUpdated callback listener as Android-only in the method documentation.

Fixes #287

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR