### PR TITLE
docs: improve example app documentation

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -25,18 +25,22 @@ This contains a sample application to showcase the functionality of the NavSDK l
     <string>Your API KEY</string>
     ```
 
-5. To run the sample app, go to the root folder of the sample app and run the command below according to platform using your preferred terminal.
+5. To run the sample app, navigate to the `example` folder in the root directory and use the following commands for your platform in the terminal.
 
-    * Running in Android:
-      `npx react-native run-android`
-    * Running in iOS:
-      `npx react-native run-ios`
+    1. Ensure all workspace dependencies are installed:
+      `yarn install`
+
+    2. Start the metro bundler:
+       * Android:
+         `npx react-native run-android`
+       * iOS:
+         `npx react-native run-ios`
 
 
-1. After the app initializes, accept the terms of services. You should see a map loaded in background if you have used the right API key.
+6. After the app initializes, accept the terms of services. You should see a map loaded in background if you have used the right API key.
 
 
 ### Android 
 1. On your Emulator, go to App Info for the installed app, then Permissions > Location and allow location for the app.
 
-1. Restart the app, now the Navigation view should be displayed instead of the map.
+2. Restart the app, now the Navigation view should be displayed instead of the map.


### PR DESCRIPTION
Fixes #275

Example app documentation was missing information how packade dependencies should be installed for example app as it is yarn workspace project. This PR improves documentation for example app.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR