### PR TITLE
chore: npm install for example app on non-MacOS devices

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,6 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "test": "jest",
-    "prepare": "cd ios && pod install",
     "build:android": "cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
     "build:ios": "cd ios && xcodebuild -workspace SampleApp.xcworkspace -scheme SampleApp -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO"
   },


### PR DESCRIPTION
Fixes `npm install` issue on non-macos devices.