### PR TITLE
feat: support navigation disposal on app exit on android

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
+++ b/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
@@ -44,14 +44,11 @@ public class EnumTranslationUtil {
   }
 
   public static @Navigator.TaskRemovedBehavior int getTaskRemovedBehaviourFromJsValue(int jsValue) {
-    switch (jsValue) {
-      case 0:
-        return Navigator.TaskRemovedBehavior.CONTINUE_SERVICE;
-      case 1:
-        return Navigator.TaskRemovedBehavior.QUIT_SERVICE;
-      default:
-        return Navigator.TaskRemovedBehavior.CONTINUE_SERVICE;
-    }
+    return switch (jsValue) {
+      case 0 -> Navigator.TaskRemovedBehavior.CONTINUE_SERVICE;
+      case 1 -> Navigator.TaskRemovedBehavior.QUIT_SERVICE;
+      default -> Navigator.TaskRemovedBehavior.CONTINUE_SERVICE;
+    };
   }
 
   public static int getMapTypeFromJsValue(int jsValue) {

--- a/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
+++ b/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
@@ -43,6 +43,17 @@ public class EnumTranslationUtil {
     }
   }
 
+  public static @Navigator.TaskRemovedBehavior int getTaskRemovedBehaviourFromJsValue(int jsValue) {
+    switch (jsValue) {
+      case 0:
+        return Navigator.TaskRemovedBehavior.CONTINUE_SERVICE;
+      case 1:
+        return Navigator.TaskRemovedBehavior.QUIT_SERVICE;
+      default:
+        return Navigator.TaskRemovedBehavior.CONTINUE_SERVICE;
+    }
+  }
+
   public static int getMapTypeFromJsValue(int jsValue) {
     switch (jsValue) {
       case 1:

--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -75,7 +75,7 @@ public class NavModule extends ReactContextBaseJavaModule implements INavigation
   private boolean mIsListeningRoadSnappedLocation = false;
 
   private HashMap<String, Object> tocParamsMap;
-  private Navigator.TaskRemovedBehavior taskRemovedBehaviour;
+  private @Navigator.TaskRemovedBehavior int taskRemovedBehaviour;
 
   public interface ModuleReadyListener {
     void onModuleReady();
@@ -217,9 +217,11 @@ public class NavModule extends ReactContextBaseJavaModule implements INavigation
   }
 
   @ReactMethod
-  public void initializeNavigator(@Nullable ReadableMap tocParams, int taskRemovedBehaviourJsValue) {
+  public void initializeNavigator(
+      @Nullable ReadableMap tocParams, int taskRemovedBehaviourJsValue) {
     this.tocParamsMap = tocParams.toHashMap();
-    this.taskRemovedBehaviour = EnumTranslationUtil.getTaskRemovedBehaviourFromJsValue(taskRemovedBehaviourJsValue);
+    this.taskRemovedBehaviour =
+        EnumTranslationUtil.getTaskRemovedBehaviourFromJsValue(taskRemovedBehaviourJsValue);
 
     if (getTermsAccepted()) {
       initializeNavigationApi();

--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -75,6 +75,7 @@ public class NavModule extends ReactContextBaseJavaModule implements INavigation
   private boolean mIsListeningRoadSnappedLocation = false;
 
   private HashMap<String, Object> tocParamsMap;
+  private Navigator.TaskRemovedBehavior taskRemovedBehaviour;
 
   public interface ModuleReadyListener {
     void onModuleReady();
@@ -216,8 +217,10 @@ public class NavModule extends ReactContextBaseJavaModule implements INavigation
   }
 
   @ReactMethod
-  public void initializeNavigator(@Nullable ReadableMap tocParams) {
+  public void initializeNavigator(@Nullable ReadableMap tocParams, int taskRemovedBehaviourJsValue) {
     this.tocParamsMap = tocParams.toHashMap();
+    this.taskRemovedBehaviour = EnumTranslationUtil.getTaskRemovedBehaviourFromJsValue(taskRemovedBehaviourJsValue);
+
     if (getTermsAccepted()) {
       initializeNavigationApi();
     } else {
@@ -270,6 +273,7 @@ public class NavModule extends ReactContextBaseJavaModule implements INavigation
           public void onNavigatorReady(Navigator navigator) {
             // Keep a reference to the Navigator (used to configure and start nav)
             mNavigator = navigator;
+            mNavigator.setTaskRemovedBehavior(taskRemovedBehaviour);
             mRoadSnappedLocationProvider =
                 NavigationApi.getRoadSnappedLocationProvider(getCurrentActivity().getApplication());
             onNavigationReady();

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -26,6 +26,7 @@ import NavigationScreen from './screens/NavigationScreen';
 import MultipleMapsScreen from './screens/MultipleMapsScreen';
 import {
   NavigationProvider,
+  TaskRemovedBehavior,
   type TermsAndConditionsDialogOptions,
 } from '@googlemaps/react-native-navigation-sdk';
 
@@ -67,6 +68,7 @@ export default function App() {
   return (
     <NavigationProvider
       termsAndConditionsDialogOptions={termsAndConditionsDialogOptions}
+      taskRemovedBehavior={TaskRemovedBehavior.CONTINUE_SERVICE}
     >
       <NavigationContainer>
         <Stack.Navigator initialRouteName="Home">

--- a/src/navigation/navigation/NavigationProvider.tsx
+++ b/src/navigation/navigation/NavigationProvider.tsx
@@ -19,6 +19,7 @@ import type {
   NavigationController,
   NavigationCallbacks,
   TermsAndConditionsDialogOptions,
+  TaskRemovedBehavior,
 } from './types';
 import { useNavigationController } from './useNavigationController';
 
@@ -34,15 +35,20 @@ const NavigationContext = createContext<NavigationContextProps | undefined>(
 
 interface NavigationProviderProps {
   termsAndConditionsDialogOptions: TermsAndConditionsDialogOptions;
+  taskRemovedBehavior?: TaskRemovedBehavior;
   children: ReactNode;
 }
 
 export const NavigationProvider = ({
   termsAndConditionsDialogOptions,
+  taskRemovedBehavior,
   children,
 }: NavigationProviderProps) => {
   const { navigationController, addListeners, removeListeners } =
-    useNavigationController(termsAndConditionsDialogOptions);
+    useNavigationController(
+      termsAndConditionsDialogOptions,
+      taskRemovedBehavior
+    );
   return (
     <NavigationContext.Provider
       value={{

--- a/src/navigation/navigation/types.ts
+++ b/src/navigation/navigation/types.ts
@@ -393,6 +393,16 @@ export interface NavigationController {
 }
 
 /**
+ * Defines how application should behave when a application task is removed.
+ */
+export enum TaskRemovedBehavior {
+  /** The default state, indicating that navigation guidance, location updates, and notification should persist after user removes the application task. */
+  CONTINUE_SERVICE = 0,
+  /** Indicates that navigation guidance, location updates, and notification should shut down immediately when the user removes the application task. */
+  QUIT_SERVICE,
+}
+
+/**
  * Defines the turn-by-turn event data.
  */
 export interface TurnByTurnEvent {}

--- a/src/navigation/navigation/useNavigationController.ts
+++ b/src/navigation/navigation/useNavigationController.ts
@@ -22,13 +22,14 @@ import type {
   RouteSegment,
   TimeAndDistance,
 } from '../types';
-import type {
-  NavigationCallbacks,
-  TermsAndConditionsDialogOptions,
-  NavigationController,
-  RoutingOptions,
-  SpeedAlertOptions,
-  LocationSimulationOptions,
+import {
+  type NavigationCallbacks,
+  type TermsAndConditionsDialogOptions,
+  type NavigationController,
+  type RoutingOptions,
+  type SpeedAlertOptions,
+  type LocationSimulationOptions,
+  TaskRemovedBehavior,
 } from './types';
 import { getRouteStatusFromStringValue } from '../navigationView';
 import { useMemo } from 'react';
@@ -37,7 +38,8 @@ const { NavModule, NavEventDispatcher } = NativeModules;
 const androidBridge: string = 'NavJavascriptBridge';
 
 export const useNavigationController = (
-  termsAndConditionsDialogOptions: TermsAndConditionsDialogOptions
+  termsAndConditionsDialogOptions: TermsAndConditionsDialogOptions,
+  taskRemovedBehavior: TaskRemovedBehavior = TaskRemovedBehavior.CONTINUE_SERVICE
 ): {
   navigationController: NavigationController;
   addListeners: (listeners: Partial<NavigationCallbacks>) => void;
@@ -79,7 +81,8 @@ export const useNavigationController = (
     () => ({
       init: async () => {
         return await NavModule.initializeNavigator(
-          termsAndConditionsDialogOptions
+          termsAndConditionsDialogOptions,
+          taskRemovedBehavior
         );
       },
 

--- a/src/navigation/navigation/useNavigationController.ts
+++ b/src/navigation/navigation/useNavigationController.ts
@@ -195,7 +195,11 @@ export const useNavigationController = (
         },
       },
     }),
-    [moduleListenersHandler, termsAndConditionsDialogOptions]
+    [
+      moduleListenersHandler,
+      taskRemovedBehavior,
+      termsAndConditionsDialogOptions,
+    ]
   );
 
   return {


### PR DESCRIPTION
Fixes #34 

Introduces a new property `taskRemovedBehavior` to NavigationProvider that can be used to tell Android sdk to close navigation on application exit or to keep it running:

```tsx
<NavigationProvider
  termsAndConditionsDialogOptions={termsAndConditionsDialogOptions}
  taskRemovedBehavior={TaskRemovedBehavior.CONTINUE_SERVICE}
>
```

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR