### PR TITLE
ci: increase ios-build timeout to 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
 
   build-ios:
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       TURBO_CACHE_DIR: .turbo/ios
     steps:


### PR DESCRIPTION
Extend the timeout for the ios-build job to 45 minutes, as the previous 30-minute limit was insufficient for some builds.