### PR TITLE
fix: limit supported react native version to <0.75.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains a React Native plugin that provides a [Google Navigatio
 | ------------------------------- | ------- | --------- |
 | **Minimum mobile OS supported** | SDK 23+ | iOS 15.0+ |
 
-* A React Native project with supported versions `>=0.74.1 <0.76.0`
+* A React Native project with supported version `<0.75.0`
 * A Google Cloud project
   *  If you are a Mobility Services developer, you must contact Sales as described in [Mobility services documentation](https://developers.google.com/maps/documentation/transportation-logistics/mobility).
   *  If you are not a Mobility Services developer, refer to [Setup Google Cloud Project](https://developers.google.com/maps/documentation/navigation/android-sdk/cloud-setup) for instructions.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains a React Native plugin that provides a [Google Navigatio
 | ------------------------------- | ------- | --------- |
 | **Minimum mobile OS supported** | SDK 23+ | iOS 15.0+ |
 
-* A React Native project
+* A React Native project with supported versions `>=0.74.1 <0.76.0`
 * A Google Cloud project
   *  If you are a Mobility Services developer, you must contact Sales as described in [Mobility services documentation](https://developers.google.com/maps/documentation/transportation-logistics/mobility).
   *  If you are not a Mobility Services developer, refer to [Setup Google Cloud Project](https://developers.google.com/maps/documentation/navigation/android-sdk/cloud-setup) for instructions.

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.74.1 <0.76.0"
+    "react-native": "<0.75.0"
   },
   "workspaces": [
     "example"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": ">=0.74.1 <0.76.0"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,7 +1983,7 @@ __metadata:
     typescript: ">=4.3.5 <5.4.0"
   peerDependencies:
     react: "*"
-    react-native: ">=0.74.1 <0.76.0"
+    react-native: <0.75.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,7 +1983,7 @@ __metadata:
     typescript: ">=4.3.5 <5.4.0"
   peerDependencies:
     react: "*"
-    react-native: "*"
+    react-native: ">=0.74.1 <0.76.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The current version of this package does not support the latest React Native releases 0.75+. To prevent compatibility issues, this package should limit its peer dependency to versions below 0.75.0, providing users with an immediate indication of incompatibility.

Support for React Native 0.76+ is being tracked in a separate issue: #331

By limiting the peer dependency, users will see an informative error message if they attempt to use the package with an unsupported React Native version:

```sh
❯ npm i
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: AwesomeProject@0.0.1
npm error Found: react-native@0.76.1
npm error node_modules/react-native
npm error   react-native@"0.76.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer react-native@">=0.74.1 <0.75.0" from @googlemaps/react-native-navigation-sdk@0.8.1
npm error node_modules/@googlemaps/react-native-navigation-sdk
...
```

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR