### PR TITLE
chore: update release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,3 +52,4 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_ready }}
     uses: ./.github/workflows/publish.yml
+    secrets: inherit


### PR DESCRIPTION
Pass secrets inheritance to the publish workflow since calling publish from release-please workflow is failing.