### PR TITLE
fix: fix android set zoom gestures function

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/Command.java
+++ b/android/src/main/java/com/google/android/react/navsdk/Command.java
@@ -36,7 +36,7 @@ public enum Command {
   SET_SCROLL_GESTURES_ENABLED_DURING_ROTATE_OR_ZOOM(
       18, "setScrollGesturesEnabledDuringRotateOrZoom"),
   SET_TILT_GESTURES_ENABLED(19, "setTiltGesturesEnabled"),
-  SET_ZOOM_GESTURES_ENABLED(20, "setZoomGestures"),
+  SET_ZOOM_GESTURES_ENABLED(20, "setZoomGesturesEnabled"),
   SET_BUILDINGS_ENABLED(21, "setBuildingsEnabled"),
   SET_MAP_TYPE(22, "setMapType"),
   SET_MAP_TOOLBAR_ENABLED(23, "setMapToolbarEnabled"),


### PR DESCRIPTION
Set zoom gestures command was not properly implemented on Android. This PR fixes it.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR