### PR TITLE
chore(readme): add GoogleMaps.h import in the readme file, required for GMS to work. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ ENV['RCT_NEW_ARCH_ENABLED'] = '0'
 To set up, specify your API key in the application delegate `ios/Runner/AppDelegate.m`:
 
 ```objective-c
+#import <GoogleMaps/GoogleMaps.h>
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -118,6 +120,8 @@ To set up, specify your API key in the application delegate `ios/Runner/AppDeleg
 }
 
 ```
+
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -376,5 +376,3 @@ This package is offered via an open source license. It is not governed by the Go
 This package adheres to [semantic versioning](https://semver.org/) to indicate when backwards-incompatible changes are introduced. Accordingly, while the library is in version 0.x, backwards-incompatible changes may be introduced at any time.
 
 If you find a bug, or have a feature request, please [file an issue](https://github.com/googlemaps/react-native-navigation-sdk/issues) on GitHub. If you would like to get answers to technical questions from other Google Maps Platform developers, ask through one of our [developer community channels](https://developers.google.com/maps/developer-community). If you'd like to contribute, please check the [Contributing guide](https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md).
-
-

--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ To set up, specify your API key in the application delegate `ios/Runner/AppDeleg
 
 ```
 
-
-
 ## Usage
 
 ### Initializing Navigation


### PR DESCRIPTION
GMSServices won't work if we don't import GoogleMaps.h

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR