### PR TITLE
chore: update Navigation SDK for Android to version 6.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,6 @@ dependencies {
     implementation "androidx.car.app:app-projected:1.4.0"
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation "com.google.android.libraries.navigation:navigation:6.0.2"
+    implementation "com.google.android.libraries.navigation:navigation:6.1.0"
     api 'com.google.guava:guava:31.0.1-android'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     implementation "androidx.car.app:app-projected:1.4.0"
 
     // Include the Google Navigation SDK.
-    implementation 'com.google.android.libraries.navigation:navigation:6.0.2'
+    implementation 'com.google.android.libraries.navigation:navigation:6.1.0'
 
     // Desugar Java 8+ APIs
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'


### PR DESCRIPTION
Updates navigation sdk for Android to version 6.1.0.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/