### PR TITLE
nits: correct filename casing in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ The Google Navigation SDK React Native library offers functionalities that neces
 > [!NOTE]
 > The management of these permissions falls outside the scope of the Navigation SDKs for Android and iOS. As a developer integrating these SDKs into your applications, you are responsible for requesting and obtaining the necessary permissions from the users of your app.
 
-You can see example of handling permissions in the [app.tsx](./example/src/app.tsx) file of the sample application:
+You can see example of handling permissions in the [App.tsx](./example/src/App.tsx) file of the sample application:
 
 ```tsx
 import {request, PERMISSIONS, RESULTS} from 'react-native-permissions';


### PR DESCRIPTION

Just fixed typo in README file. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.
