### PR TITLE
docs: typedoc deprecation for showStopSigns and showTrafficLights

### DIFF
--- a/src/navigation/navigation/types.ts
+++ b/src/navigation/navigation/types.ts
@@ -71,14 +71,20 @@ export interface DisplayOptions {
    * If true, destination markers are shown.
    */
   showDestinationMarkers?: boolean;
+
   /**
+   * @deprecated Stop signs are enabled by default and this option will be removed in a future release.
+   *
    * Configures whether stop signs are shown during navigation.
    * If true, stop signs are shown.
    *
    * Defaults to true.
    */
   showStopSigns?: boolean;
+
   /**
+   * @deprecated Traffic lights are enabled by default and this option will be removed in a future release.
+   *
    * Configures whether traffic lights are shown during navigation.
    * If true, traffic lights are shown.
    *
@@ -124,6 +130,7 @@ export interface ArrivalEvent {
    * Waypoint the device has arrived to. This waypoint was used when setDestinations was called.
    */
   waypoint: Waypoint;
+
   /** Whether this is the last waypoint to be visited in the route */
   isFinalDestination?: boolean;
 }


### PR DESCRIPTION
Current versions of native SDK's have deprecated the showStopSigns and showTrafficLights options.
This PR adds deprecation annotation for these parameters for typescript.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/