### PR TITLE
revert: "feat: upgrade iOS SDK version to 10.4.0 (#482)"

### DIFF
--- a/react-native-navigation-sdk.podspec
+++ b/react-native-navigation-sdk.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency "GoogleNavigation", "10.4.0"
+  s.dependency "GoogleNavigation", "10.3.0"
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
This reverts commit 366e0e6cad996756803de347ee68d8502614b13d.

iOS SDK version 10.4.0 has issues that blocks version upgrade.
This commit reverts iOS SDK back to version 10.3.0.

Fixes: #487

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/