### PR TITLE
feat: support for setting map color schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,15 @@ You can also add a bare `MapView` that works as a normal map view without naviga
 />
 ```
 
+### Control light and dark modes
+
+Use the `mapColorScheme` prop on both `NavigationView` and `MapView` to force the map tiles into light, dark, or system-following mode.
+
+For the navigation UI, pass the `navigationNightMode` prop to `NavigationView` to configure the initial lighting mode for navigation session.
+
+> [!NOTE]
+> When navigation UI is enabled, `mapColorScheme` does not affect the view styling. To control the style of the navigation UI, use the `navigationNightMode` prop on `NavigationView` instead.
+
 ### Requesting and handling permissions
 
 The Google Navigation SDK React Native library offers functionalities that necessitate specific permissions from the mobile operating system. These include, but are not limited to, location services, background execution, and receiving background location updates.

--- a/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
+++ b/android/src/main/java/com/google/android/react/navsdk/EnumTranslationUtil.java
@@ -15,6 +15,7 @@ package com.google.android.react.navsdk;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMap.CameraPerspective;
+import com.google.android.gms.maps.model.MapColorScheme;
 import com.google.android.libraries.navigation.AlternateRoutesStrategy;
 import com.google.android.libraries.navigation.ForceNightMode;
 import com.google.android.libraries.navigation.Navigator;
@@ -95,5 +96,16 @@ public class EnumTranslationUtil {
       case 1 -> CustomTypes.MapViewType.NAVIGATION;
       default -> throw new IllegalStateException("Unexpected MapViewType value: " + jsValue);
     };
+  }
+
+  public static @MapColorScheme int getMapColorSchemeFromJsValue(int jsValue) {
+    switch (jsValue) {
+      case 1:
+        return MapColorScheme.LIGHT;
+      case 2:
+        return MapColorScheme.DARK;
+      default:
+        return MapColorScheme.FOLLOW_SYSTEM;
+    }
   }
 }

--- a/android/src/main/java/com/google/android/react/navsdk/IMapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/IMapViewFragment.java
@@ -15,6 +15,7 @@ package com.google.android.react.navsdk;
 
 import android.view.View;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.MapColorScheme;
 
 public interface IMapViewFragment {
   MapViewController getMapController();
@@ -22,6 +23,8 @@ public interface IMapViewFragment {
   void setMapStyle(String url);
 
   GoogleMap getGoogleMap();
+
+  void setMapColorScheme(@MapColorScheme int colorScheme);
 
   // Fragment
   boolean isAdded();

--- a/android/src/main/java/com/google/android/react/navsdk/INavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/INavViewFragment.java
@@ -13,6 +13,7 @@
  */
 package com.google.android.react.navsdk;
 
+import com.google.android.libraries.navigation.ForceNightMode;
 import com.google.android.libraries.navigation.StylingOptions;
 
 public interface INavViewFragment extends IMapViewFragment {
@@ -34,7 +35,7 @@ public interface INavViewFragment extends IMapViewFragment {
 
   void showRouteOverview();
 
-  void setNightModeOption(int jsValue);
+  void setNightModeOption(@ForceNightMode int nightModeOverride);
 
   void setReportIncidentButtonEnabled(boolean enabled);
 

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
@@ -28,6 +28,7 @@ import com.google.android.gms.maps.model.CircleOptions;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.GroundOverlayOptions;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.MapColorScheme;
 import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
@@ -511,6 +512,14 @@ public class MapViewController {
     }
 
     mGoogleMap.setMapType(EnumTranslationUtil.getMapTypeFromJsValue(jsValue));
+  }
+
+  public void setColorScheme(@MapColorScheme int mapColorScheme) {
+    if (mGoogleMap == null) {
+      return;
+    }
+
+    mGoogleMap.setMapColorScheme(mapColorScheme);
   }
 
   public void clearMapView() {

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewFragment.java
@@ -30,6 +30,7 @@ import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.MapColorScheme;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
@@ -46,6 +47,7 @@ public class MapViewFragment extends SupportMapFragment
   private ReactApplicationContext reactContext;
   private GoogleMap mGoogleMap;
   private MapViewController mMapViewController;
+  private @MapColorScheme int mapColorScheme = MapColorScheme.FOLLOW_SYSTEM;
 
   public static MapViewFragment newInstance(
       ReactApplicationContext reactContext, int viewTag, @NonNull GoogleMapOptions mapOptions) {
@@ -74,6 +76,7 @@ public class MapViewFragment extends SupportMapFragment
 
           // Setup map listeners with the provided callback
           mMapViewController.setupMapListeners(MapViewFragment.this);
+          applyMapColorSchemeToMap();
 
           emitEvent("onMapReady", null);
 
@@ -135,6 +138,18 @@ public class MapViewFragment extends SupportMapFragment
 
   public GoogleMap getGoogleMap() {
     return mGoogleMap;
+  }
+
+  @Override
+  public void setMapColorScheme(@MapColorScheme int mapColorScheme) {
+    this.mapColorScheme = mapColorScheme;
+    applyMapColorSchemeToMap();
+  }
+
+  private void applyMapColorSchemeToMap() {
+    if (mMapViewController != null) {
+      mMapViewController.setColorScheme(mapColorScheme);
+    }
   }
 
   private void emitEvent(String eventName, @Nullable WritableMap data) {

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
@@ -29,9 +29,11 @@ import com.google.android.gms.maps.GoogleMapOptions;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.MapColorScheme;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
+import com.google.android.libraries.navigation.ForceNightMode;
 import com.google.android.libraries.navigation.NavigationView;
 import com.google.android.libraries.navigation.PromptVisibilityChangedListener;
 import com.google.android.libraries.navigation.StylingOptions;
@@ -49,6 +51,8 @@ public class NavViewFragment extends SupportNavigationFragment
   private MapViewController mMapViewController;
   private GoogleMap mGoogleMap;
   private StylingOptions mStylingOptions;
+  private @MapColorScheme int mapColorScheme = MapColorScheme.FOLLOW_SYSTEM;
+  private @ForceNightMode int nightModeOverride = ForceNightMode.AUTO;
 
   public static NavViewFragment newInstance(
       ReactApplicationContext reactContext, int viewTag, @NonNull GoogleMapOptions mapOptions) {
@@ -79,6 +83,8 @@ public class NavViewFragment extends SupportNavigationFragment
 
           // Setup map listeners with the provided callback
           mMapViewController.setupMapListeners(NavViewFragment.this);
+          applyMapColorSchemeToMap();
+          applyNightModePreference();
 
           emitEvent("onMapReady", null);
 
@@ -131,8 +137,15 @@ public class NavViewFragment extends SupportNavigationFragment
     applyStylingOptions();
   }
 
-  public void setNightModeOption(int jsValue) {
-    super.setForceNightMode(EnumTranslationUtil.getForceNightModeFromJsValue(jsValue));
+  public void setNightModeOption(@ForceNightMode int nightModeOverride) {
+    this.nightModeOverride = nightModeOverride;
+    applyNightModePreference();
+  }
+
+  @Override
+  public void setMapColorScheme(@MapColorScheme int mapColorScheme) {
+    this.mapColorScheme = mapColorScheme;
+    applyMapColorSchemeToMap();
   }
 
   @Override
@@ -189,6 +202,16 @@ public class NavViewFragment extends SupportNavigationFragment
 
   public GoogleMap getGoogleMap() {
     return mGoogleMap;
+  }
+
+  private void applyMapColorSchemeToMap() {
+    if (mMapViewController != null) {
+      mMapViewController.setColorScheme(mapColorScheme);
+    }
+  }
+
+  private void applyNightModePreference() {
+    super.setForceNightMode(nightModeOverride);
   }
 
   private void cleanup() {

--- a/example/src/controls/mapsControls.tsx
+++ b/example/src/controls/mapsControls.tsx
@@ -21,6 +21,7 @@ import { Button, Text, TextInput, View } from 'react-native';
 import SelectDropdown from 'react-native-select-dropdown';
 import { ControlStyles } from '../styles/components';
 import {
+  MapColorScheme,
   type MapViewController,
   MapType,
   type Marker,
@@ -31,12 +32,26 @@ import {
 
 export interface MapControlsProps {
   readonly mapViewController: MapViewController;
+  readonly mapColorScheme?: MapColorScheme;
+  readonly onMapColorSchemeChange?: (scheme: MapColorScheme) => void;
 }
 
 export const defaultZoom: number = 15;
 
-const MapsControls: React.FC<MapControlsProps> = ({ mapViewController }) => {
+const MapsControls: React.FC<MapControlsProps> = ({
+  mapViewController,
+  mapColorScheme = MapColorScheme.FOLLOW_SYSTEM,
+  onMapColorSchemeChange,
+}) => {
   const mapTypeOptions = ['None', 'Normal', 'Satellite', 'Terrain', 'Hybrid'];
+  const colorSchemeOptions = ['Follow System', 'Light', 'Dark'];
+  const colorSchemeIndex =
+    mapColorScheme === MapColorScheme.LIGHT
+      ? 1
+      : mapColorScheme === MapColorScheme.DARK
+        ? 2
+        : 0;
+  const colorSchemeLabel = colorSchemeOptions[colorSchemeIndex];
   const [zoom, setZoom] = useState<number | null>(null);
   const [enableLocationMarker, setEnableLocationMarker] = useState(true);
   const [latitude, onLatChanged] = useState('');
@@ -212,6 +227,16 @@ const MapsControls: React.FC<MapControlsProps> = ({ mapViewController }) => {
     setCustomPaddingEnabled(!customPaddingEnabled);
   };
 
+  const setMapColorScheme = (index: number) => {
+    const scheme =
+      index === 1
+        ? MapColorScheme.LIGHT
+        : index === 2
+          ? MapColorScheme.DARK
+          : MapColorScheme.FOLLOW_SYSTEM;
+    onMapColorSchemeChange?.(scheme);
+  };
+
   return (
     <View>
       <TextInput
@@ -303,6 +328,38 @@ const MapsControls: React.FC<MapControlsProps> = ({ mapViewController }) => {
         <Button
           title={customPaddingEnabled ? 'Disable' : 'Enable'}
           onPress={toggleCustomPadding}
+        />
+      </View>
+      <View style={ControlStyles.rowContainer}>
+        <Text>Map color scheme</Text>
+        <SelectDropdown
+          data={colorSchemeOptions}
+          defaultValueByIndex={colorSchemeIndex}
+          onSelect={(_item, index) => {
+            setMapColorScheme(index);
+          }}
+          renderButton={(selectedItem, _isOpened) => {
+            return (
+              <View style={ControlStyles.dropdownButton}>
+                <Text style={ControlStyles.dropdownButtonText}>
+                  {selectedItem || colorSchemeLabel}
+                </Text>
+              </View>
+            );
+          }}
+          renderItem={(item, _index, isSelected) => {
+            return (
+              <View
+                style={[
+                  ControlStyles.dropdownItem,
+                  isSelected && ControlStyles.dropdownItemSelected,
+                ]}
+              >
+                <Text style={ControlStyles.dropdownItemText}>{item}</Text>
+              </View>
+            );
+          }}
+          dropdownStyle={ControlStyles.dropdownMenu}
         />
       </View>
     </View>

--- a/example/src/controls/navigationControls.tsx
+++ b/example/src/controls/navigationControls.tsx
@@ -18,6 +18,7 @@ import React, { useState } from 'react';
 import { Alert, Button, Platform, Text, TextInput, View } from 'react-native';
 import {
   CameraPerspective,
+  NavigationNightMode,
   type NavigationViewController,
   type RoutingOptions,
   TravelMode,
@@ -35,6 +36,8 @@ export interface NavigationControlsProps {
   readonly navigationViewController: NavigationViewController;
   readonly onNavigationDispose?: () => void;
   readonly getCameraPosition: undefined | (() => Promise<CameraPosition>);
+  readonly onNavigationNightModeChange?: (mode: NavigationNightMode) => void;
+  readonly navigationNightMode?: NavigationNightMode;
 }
 
 const NavigationControls: React.FC<NavigationControlsProps> = ({
@@ -42,9 +45,18 @@ const NavigationControls: React.FC<NavigationControlsProps> = ({
   navigationViewController,
   onNavigationDispose,
   getCameraPosition,
+  onNavigationNightModeChange,
+  navigationNightMode = NavigationNightMode.AUTO,
 }) => {
   const perspectiveOptions = ['Tilted', 'North up', 'Heading up'];
   const nightModeOptions = ['Auto', 'Force Day', 'Force Night'];
+  const nightModeIndex =
+    navigationNightMode === NavigationNightMode.FORCE_DAY
+      ? 1
+      : navigationNightMode === NavigationNightMode.FORCE_NIGHT
+        ? 2
+        : 0;
+  const nightModeLabel = nightModeOptions[nightModeIndex];
   const audioGuidanceOptions = ['Silent', 'Alerts only', 'Alerts and guidance'];
   const [tripProgressBarEnabled, setTripProgressBarEnabled] = useState(false);
   const [reportIncidentButtonEnabled, setReportIncidentButtonEnabled] =
@@ -260,8 +272,13 @@ const NavigationControls: React.FC<NavigationControlsProps> = ({
   };
 
   const setNightMode = (index: number) => {
-    console.log('setNightMode: ', index);
-    navigationViewController.setNightMode(index);
+    const mode =
+      index === 1
+        ? NavigationNightMode.FORCE_DAY
+        : index === 2
+          ? NavigationNightMode.FORCE_NIGHT
+          : NavigationNightMode.AUTO;
+    onNavigationNightModeChange?.(mode);
   };
 
   const setAudioGuidanceType = (index: number) => {
@@ -484,6 +501,7 @@ const NavigationControls: React.FC<NavigationControlsProps> = ({
         <Text>Night mode </Text>
         <SelectDropdown
           data={nightModeOptions}
+          defaultValueByIndex={nightModeIndex}
           onSelect={(_selectedItem, index) => {
             setNightMode(index);
           }}
@@ -491,7 +509,7 @@ const NavigationControls: React.FC<NavigationControlsProps> = ({
             return (
               <View style={ControlStyles.dropdownButton}>
                 <Text style={ControlStyles.dropdownButtonText}>
-                  {selectedItem || 'Select'}
+                  {selectedItem || nightModeLabel}
                 </Text>
               </View>
             );

--- a/example/src/screens/MultipleMapsScreen.tsx
+++ b/example/src/screens/MultipleMapsScreen.tsx
@@ -32,6 +32,8 @@ import {
   NavigationInitErrorCode,
   NavigationView,
   RouteStatus,
+  MapColorScheme,
+  NavigationNightMode,
   type ArrivalEvent,
   type Circle,
   type LatLng,
@@ -78,6 +80,14 @@ const MultipleMapsScreen = () => {
   const [navigationViewController1, setNavigationViewController1] =
     useState<NavigationViewController | null>(null);
   const [navigationInitialized, setNavigationInitialized] = useState(false);
+  const [mapColorScheme1, setMapColorScheme1] = useState<MapColorScheme>(
+    MapColorScheme.FOLLOW_SYSTEM
+  );
+  const [mapColorScheme2, setMapColorScheme2] = useState<MapColorScheme>(
+    MapColorScheme.FOLLOW_SYSTEM
+  );
+  const [navigationNightMode, setNavigationNightMode] =
+    useState<NavigationNightMode>(NavigationNightMode.AUTO);
   const pagerRef = useRef<PagerView | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
   const { navigationController, addListeners, removeListeners } =
@@ -336,6 +346,8 @@ const MultipleMapsScreen = () => {
                 style={{ flex: 1 }}
                 androidStylingOptions={MapStylingOptions.android}
                 iOSStylingOptions={MapStylingOptions.iOS}
+                mapColorScheme={mapColorScheme1}
+                navigationNightMode={navigationNightMode}
                 navigationViewCallbacks={navigationViewCallbacks}
                 mapViewCallbacks={mapViewCallbacks1}
                 onMapViewControllerCreated={setMapViewController1}
@@ -355,6 +367,7 @@ const MultipleMapsScreen = () => {
               <MapView
                 style={{ flex: 1 }}
                 mapViewCallbacks={mapViewCallbacks2}
+                mapColorScheme={mapColorScheme2}
                 onMapViewControllerCreated={setMapViewController2}
               />
               {currentPage === 1 && (
@@ -378,6 +391,8 @@ const MultipleMapsScreen = () => {
                   navigationViewController={navigationViewController1}
                   getCameraPosition={mapViewController1?.getCameraPosition}
                   onNavigationDispose={onNavigationDispose}
+                  navigationNightMode={navigationNightMode}
+                  onNavigationNightModeChange={setNavigationNightMode}
                 />
               </OverlayModal>
             )}
@@ -387,7 +402,11 @@ const MultipleMapsScreen = () => {
               visible={overlayType === OverlayType.MapControls1}
               closeOverlay={closeOverlay}
             >
-              <MapsControls mapViewController={mapViewController1} />
+              <MapsControls
+                mapViewController={mapViewController1}
+                mapColorScheme={mapColorScheme1}
+                onMapColorSchemeChange={setMapColorScheme1}
+              />
             </OverlayModal>
           )}
 
@@ -396,7 +415,11 @@ const MultipleMapsScreen = () => {
               visible={overlayType === OverlayType.MapControls2}
               closeOverlay={closeOverlay}
             >
-              <MapsControls mapViewController={mapViewController2} />
+              <MapsControls
+                mapViewController={mapViewController2}
+                mapColorScheme={mapColorScheme2}
+                onMapColorSchemeChange={setMapColorScheme2}
+              />
             </OverlayModal>
           )}
         </React.Fragment>

--- a/example/src/screens/NavigationScreen.tsx
+++ b/example/src/screens/NavigationScreen.tsx
@@ -23,6 +23,8 @@ import {
   NavigationInitErrorCode,
   NavigationView,
   RouteStatus,
+  MapColorScheme,
+  NavigationNightMode,
   type ArrivalEvent,
   type Circle,
   type LatLng,
@@ -68,6 +70,11 @@ const NavigationScreen = () => {
     useState<MapViewController | null>(null);
   const [navigationViewController, setNavigationViewController] =
     useState<NavigationViewController | null>(null);
+  const [mapColorScheme, setMapColorScheme] = useState<MapColorScheme>(
+    MapColorScheme.FOLLOW_SYSTEM
+  );
+  const [navigationNightMode, setNavigationNightMode] =
+    useState<NavigationNightMode>(NavigationNightMode.AUTO);
 
   const {
     mapViewAutoController,
@@ -301,6 +308,8 @@ const NavigationScreen = () => {
         style={MapStyles.mapView}
         androidStylingOptions={MapStylingOptions.android}
         iOSStylingOptions={MapStylingOptions.iOS}
+        mapColorScheme={mapColorScheme}
+        navigationNightMode={navigationNightMode}
         navigationViewCallbacks={navigationViewCallbacks}
         mapViewCallbacks={mapViewCallbacks}
         onMapViewControllerCreated={setMapViewController}
@@ -319,6 +328,8 @@ const NavigationScreen = () => {
               navigationViewController={navigationViewController}
               getCameraPosition={mapViewController?.getCameraPosition}
               onNavigationDispose={onNavigationDispose}
+              navigationNightMode={navigationNightMode}
+              onNavigationNightModeChange={setNavigationNightMode}
             />
           </OverlayModal>
         )}
@@ -328,7 +339,11 @@ const NavigationScreen = () => {
           visible={overlayType === OverlayType.MapControls}
           closeOverlay={closeOverlay}
         >
-          <MapsControls mapViewController={mapViewController} />
+          <MapsControls
+            mapViewController={mapViewController}
+            mapColorScheme={mapColorScheme}
+            onMapColorSchemeChange={setMapColorScheme}
+          />
         </OverlayModal>
       )}
 

--- a/ios/react-native-navigation-sdk/NavView.h
+++ b/ios/react-native-navigation-sdk/NavView.h
@@ -40,9 +40,13 @@
 
 - (NavViewController *)initializeViewControllerWithMapViewType:(MapViewType)mapViewType
                                                          mapId:(NSString *)mapId
-                                                stylingOptions:(NSDictionary *)stylingOptions;
+                                                stylingOptions:(NSDictionary *)stylingOptions
+                                                mapColorScheme:(NSNumber *)colorScheme
+                                                     nightMode:(NSNumber *)nightMode;
 
 - (void)applyStylingOptions:(NSDictionary *)stylingOptions;
+- (void)applyMapColorScheme:(NSNumber *)colorScheme;
+- (void)applyNightMode:(NSNumber *)nightMode;
 - (NavViewController *)getViewController;
 
 @end

--- a/ios/react-native-navigation-sdk/NavView.m
+++ b/ios/react-native-navigation-sdk/NavView.m
@@ -50,7 +50,9 @@
 
 - (NavViewController *)initializeViewControllerWithMapViewType:(MapViewType)mapViewType
                                                          mapId:(NSString *)mapId
-                                                stylingOptions:(NSDictionary *)stylingOptions {
+                                                stylingOptions:(NSDictionary *)stylingOptions
+                                                mapColorScheme:(NSNumber *)colorScheme
+                                                     nightMode:(NSNumber *)nightMode {
   // Initialize view controller with the map view type
   _viewController = [[NavViewController alloc] initWithMapViewType:mapViewType];
 
@@ -60,6 +62,14 @@
 
   if (stylingOptions && [stylingOptions count] > 0) {
     [_viewController setStylingOptions:stylingOptions];
+  }
+
+  if (colorScheme) {
+    [_viewController setColorScheme:colorScheme];
+  }
+
+  if (nightMode) {
+    [_viewController setNightMode:nightMode];
   }
 
   [_viewController setNavigationViewCallbacks:self];
@@ -80,6 +90,14 @@
   if (stylingOptions != nil && [stylingOptions count] > 0) {
     [_viewController setStylingOptions:stylingOptions];
   }
+}
+
+- (void)applyMapColorScheme:(NSNumber *)colorScheme {
+  [_viewController setColorScheme:colorScheme];
+}
+
+- (void)applyNightMode:(NSNumber *)nightMode {
+  [_viewController setNightMode:nightMode];
 }
 
 - (void)handleRecenterButtonClick {

--- a/ios/react-native-navigation-sdk/NavViewController.h
+++ b/ios/react-native-navigation-sdk/NavViewController.h
@@ -32,6 +32,7 @@ typedef void (^OnArrayResult)(NSArray *_Nullable result);
 - (instancetype)initWithMapViewType:(MapViewType)mapViewType;
 - (void)setStylingOptions:(nonnull NSDictionary *)stylingOptions;
 - (void)setMapId:(NSString *)mapId;
+- (void)setColorScheme:(NSNumber *)colorScheme;
 - (void)getCameraPosition:(OnDictionaryResult)completionBlock;
 - (void)getMyLocation:(OnDictionaryResult)completionBlock;
 - (void)getUiSettings:(OnDictionaryResult)completionBlock;

--- a/ios/react-native-navigation-sdk/RCTNavViewManager.m
+++ b/ios/react-native-navigation-sdk/RCTNavViewManager.m
@@ -102,21 +102,36 @@ RCT_EXPORT_VIEW_PROPERTY(onCircleClick, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onGroundOverlayClick, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPromptVisibilityChanged, RCTDirectEventBlock);
 
-RCT_CUSTOM_VIEW_PROPERTY(mapInitializationOptions, NSDictionary *, NavView) {
+RCT_CUSTOM_VIEW_PROPERTY(mapOptions, NSDictionary *, NavView) {
   if (json && json != (id)kCFNull) {
-    NSDictionary *mapInitializationOptions = [RCTConvert NSDictionary:json];
+    NSDictionary *mapOptions = [RCTConvert NSDictionary:json];
 
     // Extract all properties and pass them to initialization method
-    NSString *mapId = mapInitializationOptions[@"mapId"];
-    NSDictionary *stylingOptions = mapInitializationOptions[@"navigationStylingOptions"];
-    NSNumber *mapViewTypeNumber = mapInitializationOptions[@"mapViewType"];
+    id mapIdValue = mapOptions[@"mapId"];
+    NSString *mapId = [mapIdValue isKindOfClass:[NSNull class]] ? nil : mapIdValue;
+    id stylingValue = mapOptions[@"navigationStylingOptions"];
+    NSDictionary *stylingOptions =
+        [stylingValue isKindOfClass:[NSNull class]] ? nil : (NSDictionary *)stylingValue;
+    NSNumber *mapViewTypeNumber = mapOptions[@"mapViewType"];
+    id colorSchemeValue = mapOptions[@"mapColorScheme"];
+    NSNumber *mapColorScheme =
+        [colorSchemeValue isKindOfClass:[NSNull class]] ? nil : colorSchemeValue;
+    id nightModeValue = mapOptions[@"navigationNightMode"];
+    NSNumber *nightMode = [nightModeValue isKindOfClass:[NSNull class]] ? nil : nightModeValue;
 
-    if (mapViewTypeNumber) {
+    NavViewController *existingViewController = [view getViewController];
+    if (existingViewController) {
+      [view applyStylingOptions:stylingOptions];
+      [view applyMapColorScheme:mapColorScheme];
+      [view applyNightMode:nightMode];
+    } else if (mapViewTypeNumber) {
       MapViewType mapViewType = (MapViewType)[mapViewTypeNumber integerValue];
       NavViewController *viewController =
           [view initializeViewControllerWithMapViewType:mapViewType
                                                   mapId:mapId
-                                         stylingOptions:stylingOptions];
+                                         stylingOptions:stylingOptions
+                                         mapColorScheme:mapColorScheme
+                                              nightMode:nightMode];
       [self registerViewController:viewController forTag:view.reactTag];
     }
   }

--- a/src/maps/mapView/mapView.tsx
+++ b/src/maps/mapView/mapView.tsx
@@ -18,6 +18,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, View, findNodeHandle } from 'react-native';
 import { NavViewManager, type LatLng } from '../../shared';
 import {
+  MapColorScheme,
   getMapViewController,
   MapViewType,
   type Circle,
@@ -114,9 +115,10 @@ export const MapView = (props: MapViewProps): React.JSX.Element => {
       <NavViewManager
         ref={onRefAssign}
         flex={1}
-        mapInitializationOptions={{
+        mapOptions={{
           mapViewType: MapViewType.MAP,
           mapId: props.mapId,
+          mapColorScheme: props.mapColorScheme ?? MapColorScheme.FOLLOW_SYSTEM,
         }}
         onMapClick={onMapClick}
         onMapReady={onMapReady}

--- a/src/maps/types.ts
+++ b/src/maps/types.ts
@@ -161,6 +161,18 @@ export interface UISettings {
 }
 
 /**
+ * Defines the color scheme to be applied to the rendered map.
+ */
+export enum MapColorScheme {
+  /** Follows the system or SDK default (automatic). */
+  FOLLOW_SYSTEM = 0,
+  /** Forces the light color scheme. */
+  LIGHT = 1,
+  /** Forces the dark color scheme. */
+  DARK = 2,
+}
+
+/**
  * `MapViewProps` interface provides methods focused on managing map events and state changes.
  */
 export interface MapViewProps {
@@ -175,6 +187,14 @@ export interface MapViewProps {
    * The map ID must be configured in your Google Cloud Console project before use.
    */
   readonly mapId?: string;
+
+  /**
+   * Sets the preferred color scheme for the map view.
+   * Note if NavigationView is used, the `navigationNightMode` prop must be used to control night mode for navigation session.
+   *
+   * Defaults to `ColorScheme.FOLLOW_SYSTEM`.
+   */
+  readonly mapColorScheme?: MapColorScheme;
 
   onMapViewControllerCreated(mapViewController: MapViewController): void;
 }

--- a/src/navigation/navigationView/navigationView.tsx
+++ b/src/navigation/navigationView/navigationView.tsx
@@ -18,8 +18,9 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform, StyleSheet, View, findNodeHandle } from 'react-native';
 import { NavViewManager, type LatLng } from '../../shared';
 import { getNavigationViewController } from './navigationViewController';
-import type { NavigationViewProps } from './types';
+import { NavigationNightMode, type NavigationViewProps } from './types';
 import {
+  MapColorScheme,
   getMapViewController,
   MapViewType,
   type Circle,
@@ -140,9 +141,12 @@ export const NavigationView = (
       <NavViewManager
         ref={onRefAssign}
         flex={1}
-        mapInitializationOptions={{
+        mapOptions={{
           mapViewType: MapViewType.NAVIGATION,
           mapId: props.mapId,
+          mapColorScheme: props.mapColorScheme ?? MapColorScheme.FOLLOW_SYSTEM,
+          navigationNightMode:
+            props.navigationNightMode ?? NavigationNightMode.AUTO,
           navigationStylingOptions:
             (Platform.OS === 'android'
               ? androidStylingOptions

--- a/src/navigation/navigationView/navigationViewController.ts
+++ b/src/navigation/navigationView/navigationViewController.ts
@@ -56,6 +56,9 @@ export const getNavigationViewController = (
       sendCommand(viewId, commands.showRouteOverview, []);
     },
 
+    /**
+     * @deprecated Prefer the `navigationNightMode` prop on `NavigationView`.
+     */
     setNightMode: (index: number) => {
       sendCommand(viewId, commands.setNightMode, [index]);
     },

--- a/src/navigation/navigationView/types.ts
+++ b/src/navigation/navigationView/types.ts
@@ -57,11 +57,33 @@ export interface NavigationViewProps extends MapViewProps {
   readonly androidStylingOptions?: AndroidStylingOptions;
   readonly iOSStylingOptions?: iOSStylingOptions;
 
+  /**
+   * Controls the navigation night mode for Navigation UI.
+   *
+   * Defaults to `NavigationNightMode.AUTO` when not provided.
+   */
+  readonly navigationNightMode?: NavigationNightMode;
+
   readonly navigationViewCallbacks?: NavigationViewCallbacks;
 
   onNavigationViewControllerCreated(
     navigationViewController: NavigationViewController
   ): void;
+}
+
+/**
+ * Represents the navigation UI lighting mode.
+ *
+ * Android ref https://developers.google.com/maps/documentation/navigation/android-sdk/reference/com/google/android/libraries/navigation/ForceNightMode
+ * iOS ref https://developers.google.com/maps/documentation/navigation/ios-sdk/reference/objc/Enums/GMSNavigationLightingMode
+ */
+export enum NavigationNightMode {
+  /** Let the SDK automatically determine day or night. */
+  AUTO = 0,
+  /** Force day mode regardless of time or location. */
+  FORCE_DAY = 1,
+  /** Force night mode regardless of time or location. */
+  FORCE_NIGHT = 2,
 }
 
 /**
@@ -142,11 +164,19 @@ export interface NavigationViewController {
    * This controls whether the navigation UI should be displayed in day or night mode,
    * affecting the color scheme and visibility of UI elements.
    *
-   * @param mode - The night mode setting to apply. Valid values are:
-   *   - `0` (AUTO): The Navigation SDK automatically determines the appropriate
-   *     day or night mode according to the user's location and local time.
-   *   - `1` (FORCE_DAY): Forces day mode regardless of time or location.
-   *   - `2` (FORCE_NIGHT): Forces night mode regardless of time or location.
+   * Android (ForceNightMode reference:
+   * https://developers.google.com/maps/documentation/navigation/android-sdk/reference/com/google/android/libraries/navigation/ForceNightMode):
+   *   - `0` (AUTO): Let the SDK automatically determine day or night.
+   *   - `1` (FORCE_DAY): Force day mode regardless of time or location.
+   *   - `2` (FORCE_NIGHT): Force night mode regardless of time or location.
+   *
+   * iOS (GMSNavigationLightingMode reference:
+   * https://developers.google.com/maps/documentation/navigation/ios-sdk/reference/objc/Enums/GMSNavigationLightingMode):
+   *   - `0` (AUTO): Resets to automatic (SDK-managed) lighting.
+   *   - `1` (FORCE_DAY): Renders the light (day) UI.
+   *   - `2` (FORCE_NIGHT): Renders the dark (night) UI.
+   *
+   * @deprecated Prefer the `navigationNightMode` view prop so the desired mode is applied as early as possible.
    *
    * @example
    * ```typescript

--- a/src/shared/viewManager.ts
+++ b/src/shared/viewManager.ts
@@ -22,12 +22,23 @@ import {
   type ViewProps,
 } from 'react-native';
 import type { LatLng } from '.';
-import type { Circle, GroundOverlay, Marker, Polygon, Polyline } from '../maps';
+import type {
+  Circle,
+  MapColorScheme,
+  GroundOverlay,
+  Marker,
+  Polygon,
+  Polyline,
+} from '../maps';
 import type {
   DirectEventHandler,
   Int32,
 } from 'react-native/Libraries/Types/CodegenTypesNamespace';
-import type { AndroidStylingOptions, iOSStylingOptions } from '../navigation';
+import type {
+  AndroidStylingOptions,
+  NavigationNightMode,
+  iOSStylingOptions,
+} from '../navigation';
 
 // NavViewManager is responsible for managing both the regular map fragment as well as the navigation map view fragment.
 export const viewManagerName =
@@ -67,10 +78,12 @@ export const commands = (
 
 export interface NativeNavViewProps extends ViewProps {
   flex?: number | undefined;
-  mapInitializationOptions: {
+  mapOptions: {
     mapViewType: Int32;
     mapId?: string;
     navigationStylingOptions?: AndroidStylingOptions | iOSStylingOptions;
+    mapColorScheme?: MapColorScheme;
+    navigationNightMode?: NavigationNightMode;
   };
   onMapReady?: DirectEventHandler<null>;
   onMapClick?: DirectEventHandler<LatLng>;


### PR DESCRIPTION
- Adds a new `mapColorScheme` view property to allow controlling the map’s light and dark modes.
- Fixes night-mode handling on iOS, including the ability to reset night mode back to automatic.
- Deprecates the `setNightMode` method and moves night-mode handling to the `navigationNightMode` view property.

Closes #499

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/