### PR TITLE
fix!: navigation session error handling

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/JsErrors.java
+++ b/android/src/main/java/com/google/android/react/navsdk/JsErrors.java
@@ -21,4 +21,7 @@ public class JsErrors {
   public static final String NO_MAP_ERROR_CODE = "NO_MAP_ERROR_CODE";
   public static final String NO_MAP_ERROR_MESSAGE =
       "Make sure to initialize the map view has been initialized before executing.";
+
+  public static final String NO_DESTINATIONS_ERROR_CODE = "NO_DESTINATIONS";
+  public static final String NO_DESTINATIONS_ERROR_MESSAGE = "Destinations not set";
 }

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -59,7 +59,7 @@ module.exports = {
       type: 'ios.simulator',
       device: {
         type: 'iPhone 16 Pro',
-        os: 'iOS 18.5',
+        os: 'iOS 18.6',
       },
     },
     attached: {

--- a/example/e2e/event_listener.test.js
+++ b/example/e2e/event_listener.test.js
@@ -20,9 +20,10 @@ import {
   selectTestByName,
   waitForTestToFinish,
   expectSuccess,
+  expectNoErrors,
 } from './shared.js';
 
-describe('Even listener tests', () => {
+describe('Event listener tests', () => {
   beforeEach(async () => {
     await initializeIntegrationTestsPage();
   });
@@ -31,6 +32,7 @@ describe('Even listener tests', () => {
     await selectTestByName('testOnRemainingTimeOrDistanceChanged');
     await agreeToTermsAndConditions();
     await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 
@@ -38,6 +40,7 @@ describe('Even listener tests', () => {
     await selectTestByName('testOnArrival');
     await agreeToTermsAndConditions();
     await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 
@@ -45,6 +48,7 @@ describe('Even listener tests', () => {
     await selectTestByName('testOnRouteChanged');
     await agreeToTermsAndConditions();
     await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 });

--- a/example/e2e/map.test.js
+++ b/example/e2e/map.test.js
@@ -19,8 +19,8 @@ import {
   selectTestByName,
   waitForTestToFinish,
   expectSuccess,
+  expectNoErrors,
 } from './shared.js';
-import { element, by, log } from 'detox';
 
 describe('Map view tests', () => {
   beforeEach(async () => {
@@ -30,30 +30,21 @@ describe('Map view tests', () => {
   it('T01 - initialize map and test default values', async () => {
     await selectTestByName('testMapInitialization');
     await waitForTestToFinish();
-    const failureMessageLabel = element(by.id('failure_message_label'));
-    const attributes = await failureMessageLabel.getAttributes();
-    log.error(attributes.text);
-    await expect(element(by.id('failure_message_label'))).toHaveText('');
+    await expectNoErrors();
     await expectSuccess();
   });
 
   it('T02 - initialize map and test move camera', async () => {
     await selectTestByName('testMoveCamera');
     await waitForTestToFinish();
-    const failureMessageLabel = element(by.id('failure_message_label'));
-    const attributes = await failureMessageLabel.getAttributes();
-    log.error(attributes.text);
-    await expect(element(by.id('failure_message_label'))).toHaveText('');
+    await expectNoErrors();
     await expectSuccess();
   });
 
   it('T03 - initialize map and test camera tilt bearing zoom', async () => {
     await selectTestByName('testTiltZoomBearingCamera');
     await waitForTestToFinish();
-    const failureMessageLabel = element(by.id('failure_message_label'));
-    const attributes = await failureMessageLabel.getAttributes();
-    log.error(attributes.text);
-    await expect(element(by.id('failure_message_label'))).toHaveText('');
+    await expectNoErrors();
     await expectSuccess();
   });
 });

--- a/example/e2e/navigation.test.js
+++ b/example/e2e/navigation.test.js
@@ -20,8 +20,8 @@ import {
   selectTestByName,
   waitForTestToFinish,
   expectSuccess,
+  expectNoErrors,
 } from './shared.js';
-import { element, by, log } from 'detox';
 
 describe('Navigation tests', () => {
   beforeEach(async () => {
@@ -32,6 +32,7 @@ describe('Navigation tests', () => {
     await selectTestByName('testNavigationSessionInitialization');
     await agreeToTermsAndConditions();
     await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 
@@ -39,6 +40,7 @@ describe('Navigation tests', () => {
     await selectTestByName('testNavigationToSingleDestination');
     await agreeToTermsAndConditions();
     await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 
@@ -46,28 +48,38 @@ describe('Navigation tests', () => {
     await selectTestByName('testNavigationToMultipleDestination');
     await agreeToTermsAndConditions();
     await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 
   it('T04 - initialize navigation controller and test route segments', async () => {
     await selectTestByName('testRouteSegments');
     await agreeToTermsAndConditions();
-    const failureMessageLabel = element(by.id('failure_message_label'));
-    const attributes = await failureMessageLabel.getAttributes();
-    log.error(attributes.text);
-    await expect(element(by.id('failure_message_label'))).toHaveText('');
     await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 
   it('T05 - initialize navigation controller and test remaining time and distance', async () => {
     await selectTestByName('testGetCurrentTimeAndDistance');
     await agreeToTermsAndConditions();
-    const failureMessageLabel = element(by.id('failure_message_label'));
-    const attributes = await failureMessageLabel.getAttributes();
-    log.error(attributes.text);
-    await expect(element(by.id('failure_message_label'))).toHaveText('');
     await waitForTestToFinish();
+    await expectNoErrors();
+    await expectSuccess();
+  });
+
+  it('T06 - expect navigation controller calls to fail when not initialized', async () => {
+    await selectTestByName('testNavigationStateGuards');
+    await waitForTestToFinish();
+    await expectNoErrors();
+    await expectSuccess();
+  });
+
+  it('T07 - require destinations before starting guidance', async () => {
+    await selectTestByName('testStartGuidanceWithoutDestinations');
+    await agreeToTermsAndConditions();
+    await waitForTestToFinish();
+    await expectNoErrors();
     await expectSuccess();
   });
 });

--- a/example/e2e/shared.js
+++ b/example/e2e/shared.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { device, element, waitFor, by, expect } from 'detox';
+import { device, element, waitFor, by, expect, log } from 'detox';
+
+const NO_ERRORS_DETECTED_LABEL = 'No errors detected';
 
 export const agreeToTermsAndConditions = async () => {
   if (device.getPlatform() === 'ios') {
@@ -37,6 +39,7 @@ export const waitForStepNumber = async number => {
 };
 
 export const waitForTestToFinish = async (timeInMs = 60000) => {
+  await expect(element(by.id('test_status_label'))).toExist();
   await waitFor(element(by.id('test_status_label')))
     .toHaveText(`Test status: Finished`)
     .withTimeout(timeInMs);
@@ -47,6 +50,17 @@ export const expectSuccess = async () => {
     'Test result: Success'
   );
 };
+
+export async function expectNoErrors() {
+  const failureMessageLabel = element(by.id('failure_message_label'));
+  const attributes = await failureMessageLabel.getAttributes();
+  if (attributes.text !== NO_ERRORS_DETECTED_LABEL) {
+    log.error(attributes.text);
+  }
+  await expect(element(by.id('failure_message_label'))).toHaveText(
+    NO_ERRORS_DETECTED_LABEL
+  );
+}
 
 export const initializeIntegrationTestsPage = async () => {
   await device.launchApp({

--- a/example/src/helpers/overlayModal.tsx
+++ b/example/src/helpers/overlayModal.tsx
@@ -29,13 +29,20 @@ interface OverlayModalProps {
   visible: boolean;
   closeOverlay: () => void;
   children: ReactNode;
+  height?: number;
 }
 
 const OverlayModal: React.FC<OverlayModalProps> = ({
   visible,
   closeOverlay,
   children,
+  height: height,
 }) => {
+  const modalContentStyle = [
+    styles.modalContent,
+    height != null ? { height } : null,
+  ];
+
   return (
     <Modal
       transparent={true}
@@ -46,10 +53,11 @@ const OverlayModal: React.FC<OverlayModalProps> = ({
       <TouchableWithoutFeedback onPress={closeOverlay}>
         <View style={styles.overlay}>
           <TouchableWithoutFeedback>
-            <View style={styles.modalContent}>
+            <View style={modalContentStyle}>
               <ScrollView
                 showsVerticalScrollIndicator={true}
                 persistentScrollbar={true}
+                style={styles.scrollContainer}
               >
                 {children}
               </ScrollView>
@@ -86,6 +94,9 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 5,
     padding: 20,
+  },
+  scrollContainer: {
+    flexGrow: 1,
   },
   closeButton: {
     padding: 10,

--- a/example/src/screens/IntegrationTestsScreen.tsx
+++ b/example/src/screens/IntegrationTestsScreen.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useState, useMemo, useCallback } from 'react';
-import { Button, Text, View } from 'react-native';
+import { Button, Text, View, useWindowDimensions } from 'react-native';
 import Snackbar from 'react-native-snackbar';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -46,6 +46,9 @@ import {
   testOnRemainingTimeOrDistanceChanged,
   testOnArrival,
   testOnRouteChanged,
+  testNavigationStateGuards,
+  testStartGuidanceWithoutDestinations,
+  NO_ERRORS_DETECTED_LABEL,
 } from './integration_tests/integration_test';
 
 // Utility function for showing Snackbar
@@ -78,10 +81,13 @@ const IntegrationTestsScreen = () => {
   const { navigationController, addListeners, removeListeners } =
     useNavigation();
   const [detoxStepNumber, setDetoxStepNumber] = useState(0);
-  const [failureMessage, setFailuremessage] = useState('');
+  const [failureMessage, setFailuremessage] = useState(
+    NO_ERRORS_DETECTED_LABEL
+  );
   const [navigationViewController, setNavigationViewController] =
     useState<NavigationViewController | null>(null);
   const insets = useSafeAreaInsets();
+  const windowDimensions = useWindowDimensions();
 
   const onMapReady = useCallback(async () => {
     console.log('Map is ready, initializing navigator...');
@@ -208,6 +214,12 @@ const IntegrationTestsScreen = () => {
       case 'testOnRouteChanged':
         await testOnRouteChanged(getTestTools());
         break;
+      case 'testNavigationStateGuards':
+        await testNavigationStateGuards(getTestTools());
+        break;
+      case 'testStartGuidanceWithoutDestinations':
+        await testStartGuidanceWithoutDestinations(getTestTools());
+        break;
       default:
         resetTestState();
         break;
@@ -220,6 +232,10 @@ const IntegrationTestsScreen = () => {
     }
     return testStatus;
   }, [testStatus, detoxStepNumber]);
+
+  const overlayMinHeight = useMemo(() => {
+    return Math.max(0, windowDimensions.height - insets.top - insets.bottom);
+  }, [windowDimensions.height, insets.top, insets.bottom]);
 
   return (
     <View style={[CommonStyles.container, { paddingBottom: insets.bottom }]}>
@@ -257,6 +273,7 @@ const IntegrationTestsScreen = () => {
         closeOverlay={() => {
           setIsOverlayOpen(false);
         }}
+        height={overlayMinHeight}
       >
         <Button
           title="testNavigationSessionInitialization"
@@ -333,6 +350,20 @@ const IntegrationTestsScreen = () => {
           testID="testOnRouteChanged"
           onPress={() => {
             runTest('testOnRouteChanged');
+          }}
+        />
+        <Button
+          title="testNavigationStateGuards"
+          testID="testNavigationStateGuards"
+          onPress={() => {
+            runTest('testNavigationStateGuards');
+          }}
+        />
+        <Button
+          title="testStartGuidanceWithoutDestinations"
+          testID="testStartGuidanceWithoutDestinations"
+          onPress={() => {
+            runTest('testStartGuidanceWithoutDestinations');
           }}
         />
       </OverlayModal>

--- a/ios/react-native-navigation-sdk/NavModule.h
+++ b/ios/react-native-navigation-sdk/NavModule.h
@@ -34,6 +34,7 @@ typedef void (^NavigationSessionDisposedCallback)(void);
 @property BOOL enableUpdateInfo;
 
 - (BOOL)hasSession;
+- (BOOL)isNavigatorAvailable;
 - (GMSNavigationSession *)getSession;
 + (void)unregisterNavigationSessionReadyCallback;
 + (void)registerNavigationSessionReadyCallback:(NavigationSessionReadyCallback)callback;


### PR DESCRIPTION
Improves error handling and guards for navigation session method calls.
Adds `NO_DESTINATIONS` error for android implementation if start guidance is called without destinations set.
Adds detox tests.

BREAKING CHANGE:
`no_destinations` error string on iOS is changed to `NO_DESTINATIONS` matching other error code formats and Android implementation

Fixes #498

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/