### PR TITLE
feat: upgrade iOS SDK to version 10.6.0

### DIFF
--- a/react-native-navigation-sdk.podspec
+++ b/react-native-navigation-sdk.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency "GoogleNavigation", "10.3.0"
+  s.dependency "GoogleNavigation", "10.6.0"
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
Upgrades the Android SDK to version 10.6.0.

Release notes: https://developers.google.com/maps/documentation/navigation/ios-sdk/release-notes#November_20_2025

This update does not introduce any changes to the React Native API.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/