### PR TITLE
fix: re-expose public iOS header files

### DIFF
--- a/example/ios/SampleApp/CarSceneDelegate.h
+++ b/example/ios/SampleApp/CarSceneDelegate.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #import <CarPlay/CarPlay.h>
-#import "BaseCarSceneDelegate.h"
+#import <ReactNativeGoogleMapsNavigation/BaseCarSceneDelegate.h>
 
 @interface CarSceneDelegate : BaseCarSceneDelegate
 @end

--- a/example/ios/SampleApp/CarSceneDelegate.m
+++ b/example/ios/SampleApp/CarSceneDelegate.m
@@ -16,8 +16,8 @@
 #import "CarSceneDelegate.h"
 #import <CarPlay/CarPlay.h>
 #import <Foundation/Foundation.h>
-#import "NavAutoModule.h"
-#import "NavModule.h"
+#import <ReactNativeGoogleMapsNavigation/NavAutoModule.h>
+#import <ReactNativeGoogleMapsNavigation/NavModule.h>
 
 @implementation CarSceneDelegate
 

--- a/example/ios/SampleApp/PhoneSceneDelegate.h
+++ b/example/ios/SampleApp/PhoneSceneDelegate.h
@@ -15,7 +15,6 @@
  */
 #import <React/RCTRootView.h>
 #import <UIKit/UIKit.h>
-#import "AppDelegateCarPlay.h"
 
 @interface PhoneSceneDelegate : UIResponder <UIWindowSceneDelegate>
 

--- a/ios/react-native-navigation-sdk/BaseCarSceneDelegate.h
+++ b/ios/react-native-navigation-sdk/BaseCarSceneDelegate.h
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 #import <CarPlay/CarPlay.h>
-#import "NavViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class NavViewController;  // forward declaration
 
 @interface BaseCarSceneDelegate
     : UIResponder <CPTemplateApplicationSceneDelegate, CPMapTemplateDelegate>
@@ -29,3 +32,5 @@
 - (CPMapTemplate *)getTemplate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ios/react-native-navigation-sdk/BaseCarSceneDelegate.m
+++ b/ios/react-native-navigation-sdk/BaseCarSceneDelegate.m
@@ -19,6 +19,7 @@
 #import "CustomTypes.h"
 #import "NavAutoModule.h"
 #import "NavModule.h"
+#import "NavViewController.h"
 
 @implementation BaseCarSceneDelegate
 

--- a/ios/react-native-navigation-sdk/NavAutoModule.h
+++ b/ios/react-native-navigation-sdk/NavAutoModule.h
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #import <React/RCTBridgeModule.h>
-#import "NavViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+@class NavViewController;  // forward declaration
 
 @interface NavAutoModule : NSObject <RCTBridgeModule>
 @property(nonatomic, strong, nullable) NavViewController *viewController;

--- a/ios/react-native-navigation-sdk/NavAutoModule.m
+++ b/ios/react-native-navigation-sdk/NavAutoModule.m
@@ -16,6 +16,7 @@
 
 #import "NavAutoModule.h"
 #import "NavAutoEventDispatcher.h"
+#import "NavViewController.h"
 
 @implementation NavAutoModule
 

--- a/react-native-navigation-sdk.podspec
+++ b/react-native-navigation-sdk.podspec
@@ -20,6 +20,8 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "react-native-navigation-sdk"
+  s.header_dir   = "ReactNativeGoogleMapsNavigation"
+  s.module_name  = "ReactNativeGoogleMapsNavigation"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]
@@ -31,8 +33,10 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
   s.public_header_files = [
-    "ios/react-native-navigation-sdk/NavModule.h",
+    "ios/react-native-navigation-sdk/BaseCarSceneDelegate.h",
     "ios/react-native-navigation-sdk/INavigationCallback.h",
+    "ios/react-native-navigation-sdk/NavAutoModule.h",
+    "ios/react-native-navigation-sdk/NavModule.h",
   ]
 
   s.dependency "React-Core"


### PR DESCRIPTION
Re-exposes ios NavModule.h and INavigationCallback.h for driver-sdk needs.
Exports headers needed by the CarPlay support.

BREAKING CHANGE:
The iOS package’s header_dir property has been changed to "ReactNativeGoogleMapsNavigation", which is a breaking change for projects that import headers directly from this package

Fixes: #503

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/