### PR TITLE
fix: setReportIncidentButtonEnabled for Android

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
@@ -143,6 +143,11 @@ public class NavViewFragment extends SupportNavigationFragment
   }
 
   @Override
+  public void setReportIncidentButtonEnabled(boolean enabled) {
+    super.setReportIncidentButtonEnabled(enabled);
+  }
+
+  @Override
   public void setMapColorScheme(@MapColorScheme int mapColorScheme) {
     this.mapColorScheme = mapColorScheme;
     applyMapColorSchemeToMap();

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -268,6 +268,9 @@ public class NavViewManager extends SimpleViewManager<FrameLayout> {
     map.put(SET_HEADER_ENABLED.toString(), SET_HEADER_ENABLED.getValue());
     map.put(SET_FOOTER_ENABLED.toString(), SET_FOOTER_ENABLED.getValue());
     map.put(SET_PADDING.toString(), SET_PADDING.getValue());
+    map.put(
+        SET_REPORT_INCIDENT_BUTTON_ENABLED.toString(),
+        SET_REPORT_INCIDENT_BUTTON_ENABLED.getValue());
     return map;
   }
 


### PR DESCRIPTION
Adds missing setReportIncidentButtonEnabled api functionality for Android implementation

Fixes #519

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/