### PR TITLE
docs: update route token example app page to support only driving travel mode

### DIFF
--- a/example/src/helpers/routesApi.ts
+++ b/example/src/helpers/routesApi.ts
@@ -14,169 +14,71 @@
  * limitations under the License.
  */
 
-// Note: This Routes API implementation is meant to be used only to
-// support the example app, and only includes the bare minimum to get
-// the route tokens.
+// Minimal Routes API implementation for fetching route tokens.
+// Route tokens are currently only supported for DRIVE travel mode.
+// See: https://developers.google.com/maps/documentation/routes/route_token
 
-import type { LatLng, Waypoint } from '@googlemaps/react-native-navigation-sdk';
+import type { LatLng } from '@googlemaps/react-native-navigation-sdk';
 
-const ROUTES_API_URL = 'https://routes.googleapis.com';
-const COMPUTE_ROUTES_URL = `${ROUTES_API_URL}/directions/v2:computeRoutes`;
-
-/**
- * Travel modes supported by the Routes API.
- */
-export type RoutesApiTravelMode = 'DRIVE' | 'BICYCLE' | 'WALK' | 'TWO_WHEELER';
+const COMPUTE_ROUTES_URL =
+  'https://routes.googleapis.com/directions/v2:computeRoutes';
 
 /**
- * Routing preference options for the Routes API.
- */
-export type RoutingPreference = 'TRAFFIC_AWARE' | 'TRAFFIC_AWARE_OPTIMAL';
-
-/**
- * Options for the Routes API request.
- */
-export interface RoutesApiOptions {
-  /** The travel mode for the route. Defaults to 'DRIVE'. */
-  travelMode?: RoutesApiTravelMode;
-  /** The routing preference. Defaults to 'TRAFFIC_AWARE'. */
-  routingPreference?: RoutingPreference;
-}
-
-/**
- * Response from the Routes API containing route tokens.
- */
-export interface RoutesApiResponse {
-  /** List of route tokens returned by the API. */
-  routeTokens: string[];
-}
-
-/**
- * Converts a Waypoint to the Routes API waypoint format.
- */
-function toRoutesApiWaypoint(
-  waypoint: Waypoint | LatLng,
-  via: boolean = false
-): Record<string, unknown> {
-  const output: Record<string, unknown> = { via };
-
-  // Check if it's a Waypoint with placeId
-  if ('placeId' in waypoint && waypoint.placeId) {
-    output.placeId = waypoint.placeId;
-  } else {
-    // Handle LatLng or Waypoint with position
-    let lat: number;
-    let lng: number;
-
-    if ('position' in waypoint && waypoint.position) {
-      lat = waypoint.position.lat;
-      lng = waypoint.position.lng;
-    } else if ('lat' in waypoint && 'lng' in waypoint) {
-      lat = waypoint.lat;
-      lng = waypoint.lng;
-    } else {
-      throw new Error(
-        'Invalid waypoint: Either position or placeId must be provided.'
-      );
-    }
-
-    const location: Record<string, unknown> = {
-      latLng: {
-        latitude: lat,
-        longitude: lng,
-      },
-    };
-
-    // Add preferred heading if available
-    if ('preferredHeading' in waypoint && waypoint.preferredHeading != null) {
-      location.heading = waypoint.preferredHeading;
-    }
-
-    output.location = location;
-  }
-
-  return output;
-}
-
-/**
- * Queries the Google Maps Routes API and returns a list of route tokens.
+ * Fetches a route token from the Google Maps Routes API.
+ * Route tokens are only supported for DRIVE travel mode.
  *
- * @param apiKey - The Google Maps API key with Routes API enabled.
- * @param waypoints - A list of waypoints representing the route (minimum 2: origin and destination).
- * @param options - Optional configuration for the route request.
- * @returns A promise that resolves to a list of route tokens.
- * @throws Error if the request fails or returns no route tokens.
+ * @param apiKey - Google Maps API key with Routes API enabled.
+ * @param origin - Starting location.
+ * @param destination - Ending location.
+ * @returns The route token string.
  *
- * @example
- * ```typescript
- * const tokens = await getRouteToken(
- *   'YOUR_API_KEY',
- *   [
- *     { lat: 37.7749, lng: -122.4194 }, // Origin
- *     { lat: 37.3382, lng: -121.8863 }, // Destination
- *   ],
- *   { travelMode: 'DRIVE' }
- * );
- * ```
+ * @see https://developers.google.com/maps/documentation/routes/route_token
  */
 export async function getRouteToken(
   apiKey: string,
-  waypoints: (Waypoint | LatLng)[],
-  options: RoutesApiOptions = {}
-): Promise<string[]> {
+  origin: LatLng,
+  destination: LatLng
+): Promise<string> {
   if (!apiKey || apiKey.trim() === '') {
-    throw new Error(
-      'API key is required. Please provide a valid Google Maps API key.'
-    );
+    throw new Error('API key is required.');
   }
-
-  if (waypoints.length < 2) {
-    throw new Error(
-      'At least two waypoints (origin and destination) are required.'
-    );
-  }
-
-  const { travelMode = 'DRIVE', routingPreference = 'TRAFFIC_AWARE' } = options;
-
-  const origin = waypoints[0]!;
-  const destination = waypoints[waypoints.length - 1]!;
-  const intermediates = waypoints.slice(1, -1);
-
-  const requestBody: Record<string, unknown> = {
-    origin: toRoutesApiWaypoint(origin),
-    destination: toRoutesApiWaypoint(destination),
-    intermediates: intermediates.map(wp => toRoutesApiWaypoint(wp, true)),
-    travelMode,
-    routingPreference,
-  };
-
-  const headers: Record<string, string> = {
-    'X-Goog-Api-Key': apiKey,
-    'X-Goog-FieldMask': 'routes.routeToken',
-    'Content-Type': 'application/json',
-  };
 
   const response = await fetch(COMPUTE_ROUTES_URL, {
     method: 'POST',
-    headers,
-    body: JSON.stringify(requestBody),
+    headers: {
+      'X-Goog-Api-Key': apiKey,
+      'X-Goog-FieldMask': 'routes.routeToken',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      origin: {
+        location: {
+          latLng: { latitude: origin.lat, longitude: origin.lng },
+        },
+      },
+      destination: {
+        location: {
+          latLng: { latitude: destination.lat, longitude: destination.lng },
+        },
+      },
+      travelMode: 'DRIVE',
+      routingPreference: 'TRAFFIC_AWARE',
+    }),
   });
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(
-      `Failed to get route tokens: ${response.statusText}\n${errorText}`
-    );
+    throw new Error(`Routes API error: ${response.statusText}\n${errorText}`);
   }
 
-  const responseData = (await response.json()) as {
-    routes?: { routeToken: string }[];
+  const data = (await response.json()) as {
+    routes?: { routeToken?: string }[];
   };
-  const routes = responseData.routes;
 
-  if (!routes || routes.length === 0) {
-    throw new Error('No routes returned from the Routes API.');
+  const routeToken = data.routes?.[0]?.routeToken;
+  if (!routeToken) {
+    throw new Error('No route token returned from the Routes API.');
   }
 
-  return routes.map(route => route.routeToken);
+  return routeToken;
 }


### PR DESCRIPTION
Route tokens are currently supported only for the Driving travel mode; therefore, we should not demonstrate other travel modes on the route tokens example page.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/