### PR TITLE
fix: release build crash with NoSuchMethodError for getNavInfoLiveData

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ android {
 
   defaultConfig {
     minSdk safeExtGet('minSdkVersion', 24)
+    consumerProguardFiles 'consumer-rules.pro'
   }
 
   compileOptions {
@@ -35,12 +36,6 @@ android {
 
   buildFeatures {
     buildConfig true
-  }
-
-  buildTypes {
-    release {
-      minifyEnabled true
-    }
   }
 
   lintOptions {

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Keep NavInfoReceivingService and its static methods - accessed from Android Auto at runtime
+-keep class com.google.android.react.navsdk.NavInfoReceivingService {
+    public static *;
+}


### PR DESCRIPTION
Fixes release build crash with `NoSuchMethodError` for `getNavInfoLiveData`

Release builds crash with _NoSuchMethodError: No static method getNavInfoLiveData()_ when using Android Auto. R8 minification was stripping `NavInfoReceivingService.getNavInfoLiveData()` because:
 - The library had minifyEnabled true (libraries shouldn't minify themselves)
 - No ProGuard keep rules existed for runtime-accessed methods

This PR removes minifyEnabled from library build (apps handle minification) and add consumer-rules.pro with keep rules for `NavInfoReceivingService` that automatically apply to consuming apps

Fixes #534

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/