### PR TITLE
fix(ios): use NSInteger for setFollowingPerspective parameter type

### DIFF
--- a/ios/react-native-navigation-sdk/NavViewModule.mm
+++ b/ios/react-native-navigation-sdk/NavViewModule.mm
@@ -476,13 +476,13 @@ static NavViewModule *sharedInstance = nil;
 }
 
 - (void)setFollowingPerspective:(NSString *)nativeID
-                    perspective:(double)perspective
+                    perspective:(NSInteger)perspective
                         resolve:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject {
   NavViewController *viewController = [self getViewControllerForNativeID:nativeID];
   if (viewController) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [viewController setFollowingPerspective:@((NSInteger)perspective)];
+      [viewController setFollowingPerspective:@(perspective)];
       resolve(nil);
     });
   } else {


### PR DESCRIPTION
The perspective parameter was declared as `double` but immediately cast to `NSInteger`. Using `NSInteger` directly avoids a lossy implicit floating-point-to-integer conversion and matches the expected enum type.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/