### PR TITLE
feat: add onCameraFollowLocationChanged callback to NavigationView

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewFragment.java
@@ -86,6 +86,23 @@ public class NavViewFragment extends SupportNavigationFragment
           applyMapColorSchemeToMap();
           applyNightModePreference();
 
+          googleMap.setOnFollowMyLocationCallback(
+              new GoogleMap.OnCameraFollowLocationCallback() {
+                @Override
+                public void onCameraStartedFollowingLocation() {
+                  WritableMap map = Arguments.createMap();
+                  map.putBoolean("isFollowing", true);
+                  emitEvent("onCameraFollowLocationChanged", map);
+                }
+
+                @Override
+                public void onCameraStoppedFollowingLocation() {
+                  WritableMap map = Arguments.createMap();
+                  map.putBoolean("isFollowing", false);
+                  emitEvent("onCameraFollowLocationChanged", map);
+                }
+              });
+
           emitEvent("onMapReady", null);
 
           // Request layout to ensure fragment is properly sized

--- a/ios/react-native-navigation-sdk/INavigationViewCallback.h
+++ b/ios/react-native-navigation-sdk/INavigationViewCallback.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleCircleClick:(GMSCircle *)circle;
 - (void)handleGroundOverlayClick:(GMSGroundOverlay *)groundOverlay;
 - (void)handlePromptVisibilityChanged:(BOOL)isVisible;
+- (void)handleCameraFollowLocationChanged:(BOOL)isFollowing;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/react-native-navigation-sdk/NavView.mm
+++ b/ios/react-native-navigation-sdk/NavView.mm
@@ -415,6 +415,11 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps =
   self.eventEmitter.onCircleClick(result);
 }
 
+- (void)handleCameraFollowLocationChanged:(BOOL)isFollowing {
+  NavViewEventEmitter::OnCameraFollowLocationChanged result = {isFollowing};
+  self.eventEmitter.onCameraFollowLocationChanged(result);
+}
+
 - (void)handleGroundOverlayClick:(GMSGroundOverlay *)groundOverlay {
   NavViewEventEmitter::OnGroundOverlayClick result = {
       [ObjectTranslationUtil isIdOnUserData:groundOverlay.userData]

--- a/ios/react-native-navigation-sdk/NavViewController.mm
+++ b/ios/react-native-navigation-sdk/NavViewController.mm
@@ -37,6 +37,7 @@
   MapViewType *_mapViewType;  // Nullable - must be set before loadView
   id<INavigationViewCallback> _viewCallbacks;
   BOOL _isSessionAttached;
+  BOOL _lastReportedIsFollowing;
   NSNumber *_isNavigationUIEnabled;
   NSNumber *_navigationUIEnabledPreference;  // 0=AUTOMATIC, 1=DISABLED
   NSNumber *_navigationLightingMode;
@@ -270,6 +271,29 @@
 
 - (void)mapViewDidTapRecenterButton:(GMSMapView *)mapView {
   [_viewCallbacks handleRecenterButtonClick];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self reportFollowingStateIfChanged];
+  });
+}
+
+- (void)mapView:(GMSMapView *)mapView willMove:(BOOL)gesture {
+  if (gesture) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self reportFollowingStateIfChanged];
+    });
+  }
+}
+
+- (void)mapView:(GMSMapView *)mapView idleAtCameraPosition:(GMSCameraPosition *)position {
+  [self reportFollowingStateIfChanged];
+}
+
+- (void)reportFollowingStateIfChanged {
+  BOOL isFollowing = (_mapView.cameraMode == GMSNavigationCameraModeFollowing);
+  if (_lastReportedIsFollowing != isFollowing) {
+    _lastReportedIsFollowing = isFollowing;
+    [_viewCallbacks handleCameraFollowLocationChanged:isFollowing];
+  }
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapInfoWindowOfMarker:(GMSMarker *)marker {
@@ -518,6 +542,7 @@
 
 - (void)showRouteOverview {
   _mapView.cameraMode = GMSNavigationCameraModeOverview;
+  [self reportFollowingStateIfChanged];
 }
 
 - (void)setTripProgressBarEnabled:(BOOL)isEnabled {
@@ -569,6 +594,7 @@
     [_mapView setFollowingPerspective:GMSNavigationCameraPerspectiveTilted];
   }
   _mapView.cameraMode = GMSNavigationCameraModeFollowing;
+  [self reportFollowingStateIfChanged];
 }
 
 - (void)setSpeedometerEnabled:(BOOL)isEnabled {

--- a/src/native/NativeNavViewComponent.ts
+++ b/src/native/NativeNavViewComponent.ts
@@ -194,6 +194,7 @@ export interface NativeNavViewProps extends ViewProps {
   }>;
   onRecenterButtonClick?: DirectEventHandler<null>;
   onPromptVisibilityChanged?: DirectEventHandler<{ visible: boolean }>;
+  onCameraFollowLocationChanged?: DirectEventHandler<{ isFollowing: boolean }>;
 }
 
 export type NativeNavViewType = HostComponent<NativeNavViewProps>;

--- a/src/navigation/navigationView/navigationView.tsx
+++ b/src/navigation/navigationView/navigationView.tsx
@@ -221,6 +221,15 @@ export const NavigationView = (
     [onPromptVisibilityChangedProp]
   );
 
+  const { onCameraFollowLocationChanged: onCameraFollowLocationChangedProp } =
+    props;
+  const onCameraFollowLocationChanged = useCallback(
+    (event: { nativeEvent: { isFollowing: boolean } }) => {
+      onCameraFollowLocationChangedProp?.(event.nativeEvent.isFollowing);
+    },
+    [onCameraFollowLocationChangedProp]
+  );
+
   return (
     <NavView
       style={props.style ?? styles.defaultStyle}
@@ -276,6 +285,7 @@ export const NavigationView = (
       onMarkerInfoWindowTapped={onMarkerInfoWindowTapped}
       onRecenterButtonClick={onRecenterButtonClick}
       onPromptVisibilityChanged={onPromptVisibilityChanged}
+      onCameraFollowLocationChanged={onCameraFollowLocationChanged}
     />
   );
 };

--- a/src/navigation/navigationView/types.ts
+++ b/src/navigation/navigationView/types.ts
@@ -67,6 +67,14 @@ export interface NavigationViewProps extends MapViewProps {
   readonly onRecenterButtonClick?: () => void;
 
   /**
+   * Callback invoked when the camera enters or exits follow-my-location mode.
+   *
+   * @param isFollowing - True when the camera is following the user's location,
+   *                      false when the user has panned or zoomed away.
+   */
+  readonly onCameraFollowLocationChanged?: (isFollowing: boolean) => void;
+
+  /**
    * A callback function invoked before a Navigation SDK UI prompt
    * element is about to appear and as soon as the element is removed.
    *


### PR DESCRIPTION
## Summary

Adds a new `onCameraFollowLocationChanged` event prop to `NavigationView` that fires whenever the camera enters or exits follow-my-location mode. This enables apps to reactively show/hide a custom recenter button or adjust their UI based on whether the map is actively tracking the user's position.

### Motivation

There is currently no way to know when the user pans the map away from the follow-my-location camera mode, or when it re-enters following mode (e.g. after tapping the built-in recenter button). Apps that overlay custom UI on top of the navigation view (such as a bottom sheet or custom recenter button) need this signal to stay in sync.

### Changes

**Android** — Uses `GoogleMap.setOnFollowMyLocationCallback` to emit `onCameraFollowLocationChanged` events when the camera starts/stops following the user's location.

**iOS** — Tracks `GMSNavigationCameraMode` transitions via `GMSMapViewDelegate` methods (`willMove:`, `idleAtCameraPosition:`, `mapViewDidTapRecenterButton:`) and reports state changes. Also fires on programmatic transitions like `showRouteOverview` and `setFollowingPerspective:`.

**TypeScript** — Adds the `onCameraFollowLocationChanged` prop to `NavigationViewProps` and wires it through `NativeNavViewComponent`.

### Usage

```tsx
<NavigationView
  onCameraFollowLocationChanged={(isFollowing) => {
    console.log('Camera is following:', isFollowing);
  }}
/>
```

## Test plan

- [x] Verify on Android: pan the map away → callback fires with `false`; tap the built-in recenter button → callback fires with `true`
- [x] Verify on iOS: same pan/recenter behavior
- [x] Verify `showRouteOverview` triggers `false` on iOS
- [x] Verify `setFollowingPerspective` triggers `true` on iOS
- [x] Verify no callback fires when the state hasn't actually changed (deduplication)


Made with [Cursor](https://cursor.com)