### PR TITLE
fix(android): respect minZoomLevel/maxZoomLevel during followMyLocation

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
@@ -22,6 +22,7 @@ import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.CameraPosition;
+import com.google.android.gms.maps.model.FollowMyLocationOptions;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.CircleOptions;
 import com.google.android.gms.maps.model.GroundOverlay;
@@ -72,6 +73,8 @@ public class MapViewController implements INavigationViewControllerProperties {
   // Zoom level preferences (-1 means use map's current value)
   private Float minZoomLevelPreference = null;
   private Float maxZoomLevelPreference = null;
+
+  private Integer currentFollowingPerspective = null;
 
   public void initialize(GoogleMap googleMap, Supplier<Activity> activitySupplier) {
     this.mGoogleMap = googleMap;
@@ -914,6 +917,8 @@ public class MapViewController implements INavigationViewControllerProperties {
     // Use map's current minZoomLevel if -1 is provided
     float effectiveMin = (minZoomLevel < 0.0f) ? mGoogleMap.getMinZoomLevel() : minZoomLevel;
     mGoogleMap.setMinZoomPreference(effectiveMin);
+
+    applyFollowMyLocation();
   }
 
   @Override
@@ -939,6 +944,8 @@ public class MapViewController implements INavigationViewControllerProperties {
     // Use map's current maxZoomLevel if -1 is provided
     float effectiveMax = (maxZoomLevel < 0.0f) ? mGoogleMap.getMaxZoomLevel() : maxZoomLevel;
     mGoogleMap.setMaxZoomPreference(effectiveMax);
+
+    applyFollowMyLocation();
   }
 
   public void setZoomGesturesEnabled(boolean enabled) {
@@ -1028,7 +1035,38 @@ public class MapViewController implements INavigationViewControllerProperties {
       return;
     }
 
-    mGoogleMap.followMyLocation(EnumTranslationUtil.getCameraPerspectiveFromJsValue(jsValue));
+    currentFollowingPerspective = jsValue;
+    applyFollowMyLocation();
+  }
+
+  private Float getLockedZoomLevel() {
+    if (minZoomLevelPreference != null
+        && maxZoomLevelPreference != null
+        && minZoomLevelPreference >= 0.0f
+        && maxZoomLevelPreference >= 0.0f
+        && Float.compare(minZoomLevelPreference, maxZoomLevelPreference) == 0) {
+      return minZoomLevelPreference;
+    }
+    return null;
+  }
+
+  @SuppressLint("MissingPermission")
+  private void applyFollowMyLocation() {
+    if (mGoogleMap == null || currentFollowingPerspective == null) {
+      return;
+    }
+
+    int perspective =
+        EnumTranslationUtil.getCameraPerspectiveFromJsValue(currentFollowingPerspective);
+    Float lockedZoom = getLockedZoomLevel();
+
+    if (lockedZoom != null) {
+      FollowMyLocationOptions options =
+          FollowMyLocationOptions.builder().setZoomLevel(lockedZoom).build();
+      mGoogleMap.followMyLocation(perspective, options);
+    } else {
+      mGoogleMap.followMyLocation(perspective);
+    }
   }
 
   public void setPadding(int top, int left, int bottom, int right) {


### PR DESCRIPTION
## Summary

- Fixes #550 — `minZoomLevel` / `maxZoomLevel` props have no effect on Android when the camera is in follow-my-location mode during active navigation.
- The single-parameter `followMyLocation(perspective)` gives the Navigation SDK full control over camera zoom, overriding `setMinZoomPreference` / `setMaxZoomPreference`. When min and max zoom are locked to the same value, this PR uses the two-parameter overload with `FollowMyLocationOptions` to enforce the fixed zoom level.
- Also re-applies `followMyLocation` whenever zoom preferences change so constraints take effect immediately, even if the camera was already following.

## Changes

**`MapViewController.java`**:
1. Added `currentFollowingPerspective` field to track the active follow perspective.
2. Added `getLockedZoomLevel()` helper that returns the zoom level when min == max (both positive), or `null` otherwise.
3. Added `applyFollowMyLocation()` — uses `FollowMyLocationOptions.builder().setZoomLevel(zoom).build()` when zoom is locked, otherwise falls back to the single-parameter `followMyLocation(perspective)`.
4. Modified `setFollowingPerspective()` to store the perspective and delegate to `applyFollowMyLocation()`.
5. Added `applyFollowMyLocation()` calls at the end of `setMinZoomLevel()` and `setMaxZoomLevel()` so that changing zoom constraints while already following re-applies the correct `followMyLocation` variant.

## Test plan

- [ ] Set `minZoomLevel={15}` and `maxZoomLevel={15}` on `NavigationView`, start navigation on Android — verify zoom is locked at 15
- [ ] Change `minZoomLevel`/`maxZoomLevel` dynamically while navigating — verify new constraints are applied immediately
- [ ] Set different min and max values (e.g. 12 and 18) — verify auto-zoom still works within those bounds
- [ ] Unset min/max (pass `undefined`) — verify the SDK reverts to normal auto-zoom behavior
- [ ] Verify iOS behavior is unchanged (no modifications to iOS code)

Made with [Cursor](https://cursor.com)