### PR TITLE
feat: upgrade Navigation SDK for Android to 7.5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,6 +58,6 @@ dependencies {
   implementation "androidx.car.app:app:1.4.0"
   implementation "androidx.car.app:app-projected:1.4.0"
   implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-  implementation "com.google.android.libraries.navigation:navigation:7.4.0"
+  implementation "com.google.android.libraries.navigation:navigation:7.5.0"
   api 'com.google.guava:guava:31.0.1-android'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -153,7 +153,7 @@ dependencies {
     implementation "androidx.car.app:app-projected:1.4.0"
 
     // Include the Google Navigation SDK.
-    implementation 'com.google.android.libraries.navigation:navigation:7.4.0'
+    implementation 'com.google.android.libraries.navigation:navigation:7.5.0'
 }
 
 secrets {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -68,8 +68,8 @@ allprojects {
                 }
 
                 dependencies {
-                    // Desugar Java 8+ APIs
-                    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
+                    // Desugar Java 8+ APIs (NIO flavor required for Navigation SDK 7.5.0+)
+                    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.4'
                 }
             }
         }


### PR DESCRIPTION
Android SDK version 7.5.0 release notes are available at:
https://developers.google.com/maps/documentation/navigation/android-sdk/release-notes#March_16_2026

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/