### PR TITLE
fix: stop navinfo forwarding on cleanup

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/NavForwardingManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavForwardingManager.java
@@ -35,7 +35,7 @@ public class NavForwardingManager {
 
   /** Unregisters the service receiving navigation updates */
   public static void stopNavForwarding(
-      Navigator navigator, Context context, INavigationCallback navigationCallback) {
+      Navigator navigator, INavigationCallback navigationCallback) {
     // Unregister the nav info receiving service.
     boolean success = navigator.unregisterServiceForNavUpdates();
     if (success) {

--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -174,8 +174,6 @@ public class NavModule extends NativeNavModuleSpec
     }
 
     final Navigator navigator = mNavigator;
-    mNavigator = null;
-    mRoadSnappedLocationProvider = null;
 
     UiThreadUtil.runOnUiThread(
         () -> {
@@ -184,6 +182,10 @@ public class NavModule extends NativeNavModuleSpec
           // where callbacks may still be in-flight during removal.
           removeLocationListener();
           removeNavigationListeners();
+          // Null out fields after listener removal so the removal methods
+          // can still access mNavigator and mRoadSnappedLocationProvider.
+          mNavigator = null;
+          mRoadSnappedLocationProvider = null;
           NavForwardingManager.stopNavForwarding(navigator, this);
           navigator.stopGuidance();
           navigator.clearDestinations();

--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -174,6 +174,9 @@ public class NavModule extends NativeNavModuleSpec
     }
 
     final Navigator navigator = mNavigator;
+    mNavigator = null;
+    mRoadSnappedLocationProvider = null;
+
     UiThreadUtil.runOnUiThread(
         () -> {
           // Remove listeners on UI thread to serialize with callback dispatch.
@@ -181,8 +184,9 @@ public class NavModule extends NativeNavModuleSpec
           // where callbacks may still be in-flight during removal.
           removeLocationListener();
           removeNavigationListeners();
-          navigator.clearDestinations();
+          NavForwardingManager.stopNavForwarding(navigator, this);
           navigator.stopGuidance();
+          navigator.clearDestinations();
           navigator.getSimulator().unsetUserLocation();
           promise.resolve(true);
         });
@@ -418,7 +422,7 @@ public class NavModule extends NativeNavModuleSpec
     if (isEnabled) {
       NavForwardingManager.startNavForwarding(mNavigator, currentActivity, this);
     } else {
-      NavForwardingManager.stopNavForwarding(mNavigator, currentActivity, this);
+      NavForwardingManager.stopNavForwarding(mNavigator, this);
     }
   }
 

--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -81,6 +81,7 @@ public class NavModule extends NativeNavModuleSpec
   private Navigator.TrafficUpdatedListener mTrafficUpdatedListener;
   private Navigator.ReroutingListener mReroutingListener;
   private Navigator.RemainingTimeOrDistanceChangedListener mRemainingTimeOrDistanceChangedListener;
+  private Observer<NavInfo> mNavInfoObserver;
 
   private @Navigator.TaskRemovedBehavior int taskRemovedBehaviour =
       Navigator.TaskRemovedBehavior.CONTINUE_SERVICE;
@@ -182,6 +183,7 @@ public class NavModule extends NativeNavModuleSpec
           // where callbacks may still be in-flight during removal.
           removeLocationListener();
           removeNavigationListeners();
+          removeNavInfoObserver();
           // Null out fields after listener removal so the removal methods
           // can still access mNavigator and mRoadSnappedLocationProvider.
           mNavigator = null;
@@ -285,14 +287,15 @@ public class NavModule extends NativeNavModuleSpec
     initializeNavigationApi();
 
     // Observe live data for nav info updates.
-    Observer<NavInfo> navInfoObserver = this::showNavInfo;
-
+    // Remove any existing observer first to prevent duplicates after cleanup+reinit cycles.
     UiThreadUtil.runOnUiThread(
         () -> {
+          removeNavInfoObserver();
+          mNavInfoObserver = this::showNavInfo;
           final Activity currentActivity = getReactApplicationContext().getCurrentActivity();
           if (currentActivity != null) {
             NavInfoReceivingService.getNavInfoLiveData()
-                .observe((LifecycleOwner) currentActivity, navInfoObserver);
+                .observe((LifecycleOwner) currentActivity, mNavInfoObserver);
           }
         });
   }
@@ -531,6 +534,13 @@ public class NavModule extends NativeNavModuleSpec
     if (mRemainingTimeOrDistanceChangedListener != null) {
       mNavigator.removeRemainingTimeOrDistanceChangedListener(
           mRemainingTimeOrDistanceChangedListener);
+    }
+  }
+
+  private void removeNavInfoObserver() {
+    if (mNavInfoObserver != null) {
+      NavInfoReceivingService.getNavInfoLiveData().removeObserver(mNavInfoObserver);
+      mNavInfoObserver = null;
     }
   }
 

--- a/example/e2e/navigation.test.js
+++ b/example/e2e/navigation.test.js
@@ -98,4 +98,12 @@ describe('Navigation tests', () => {
     await expectNoErrors();
     await expectSuccess();
   });
+
+  it('NT10 - test navInfo events are restored after cleanup and re-init', async () => {
+    await selectTestByName('testNavInfoEventsAfterCleanup');
+    await agreeToTermsAndConditions();
+    await waitForTestToFinish();
+    await expectNoErrors();
+    await expectSuccess();
+  });
 });

--- a/example/src/screens/IntegrationTestsScreen.tsx
+++ b/example/src/screens/IntegrationTestsScreen.tsx
@@ -57,6 +57,7 @@ import {
   testMapStyle,
   testMinMaxZoomLevels,
   testSetFollowingPerspective,
+  testNavInfoEventsAfterCleanup,
   NO_ERRORS_DETECTED_LABEL,
 } from './integration_tests/integration_test';
 
@@ -91,6 +92,7 @@ const IntegrationTestsScreen = () => {
     setOnLocationChanged,
     setOnRemainingTimeOrDistanceChanged,
     setOnRouteChanged,
+    setOnTurnByTurn,
   } = useNavigation();
 
   const [detoxStepNumber, setDetoxStepNumber] = useState(0);
@@ -229,6 +231,7 @@ const IntegrationTestsScreen = () => {
       setOnRemainingTimeOrDistanceChanged,
       setOnRouteChanged,
       setOnLocationChanged,
+      setOnTurnByTurn,
       passTest,
       failTest,
       setDetoxStep,
@@ -320,6 +323,9 @@ const IntegrationTestsScreen = () => {
         break;
       case 'testSetFollowingPerspective':
         await testSetFollowingPerspective(getTestTools());
+        break;
+      case 'testNavInfoEventsAfterCleanup':
+        await testNavInfoEventsAfterCleanup(getTestTools());
         break;
       default:
         resetTestState();
@@ -549,6 +555,13 @@ const IntegrationTestsScreen = () => {
             runTest('testSetFollowingPerspective');
           }}
           testID="testSetFollowingPerspective"
+        />
+        <ExampleAppButton
+          title="testNavInfoEventsAfterCleanup"
+          onPress={() => {
+            runTest('testNavInfoEventsAfterCleanup');
+          }}
+          testID="testNavInfoEventsAfterCleanup"
         />
       </OverlayModal>
     </View>

--- a/example/src/screens/integration_tests/integration_test.ts
+++ b/example/src/screens/integration_tests/integration_test.ts
@@ -28,6 +28,7 @@ import {
   type NavigationController,
   type NavigationViewController,
   type TimeAndDistance,
+  type TurnByTurnEvent,
 } from '@googlemaps/react-native-navigation-sdk';
 import { Platform } from 'react-native';
 import { delay, roundDown } from './utils';
@@ -47,6 +48,9 @@ interface TestTools {
   setOnRouteChanged: (listener: (() => void) | null | undefined) => void;
   setOnLocationChanged: (
     listener: ((location: Location) => void) | null | undefined
+  ) => void;
+  setOnTurnByTurn: (
+    listener: ((turnByTurnEvents: TurnByTurnEvent[]) => void) | null | undefined
   ) => void;
   passTest: () => void;
   failTest: (message: string) => void;
@@ -1862,6 +1866,107 @@ export const testSetFollowingPerspective = async (testTools: TestTools) => {
     } catch (error) {
       failTest(`testSetFollowingPerspective failed: ${error}`);
     }
+  });
+
+  await initializeNavigation(navigationController, failTest);
+};
+
+/**
+ * Tests that navInfo (turn-by-turn) events can be received after performing
+ * a cleanup and re-initialization cycle. This verifies that the NavForwardingManager
+ * and LiveData observer are properly restored after cleanup.
+ */
+export const testNavInfoEventsAfterCleanup = async (testTools: TestTools) => {
+  const {
+    navigationController,
+    setOnNavigationReady,
+    setOnLocationChanged,
+    setOnTurnByTurn,
+    passTest,
+    failTest,
+  } = testTools;
+
+  // Accept ToS first
+  if (!(await acceptToS(navigationController, failTest))) {
+    return;
+  }
+
+  const startLocation: LatLng = {
+    lat: 37.79136614772824,
+    lng: -122.41565900473043,
+  };
+
+  const destination = {
+    title: 'Grace Cathedral',
+    position: {
+      lat: 37.791957,
+      lng: -122.412529,
+    },
+  };
+
+  let phase: 'first' | 'second' = 'first';
+
+  setOnTurnByTurn(async (_events: TurnByTurnEvent[]) => {
+    if (phase === 'first') {
+      // Received navInfo in first session — now cleanup and re-init
+      phase = 'second';
+      setOnTurnByTurn(null);
+
+      await navigationController.cleanup();
+
+      // Re-initialize after cleanup
+      setOnNavigationReady(async () => {
+        disableVoiceGuidanceForTests(navigationController);
+        navigationController.setTurnByTurnLoggingEnabled(true);
+
+        const located2 = await simulateAndWaitForLocation(
+          navigationController,
+          setOnLocationChanged,
+          startLocation
+        );
+        if (!located2) {
+          return failTest(
+            'Timed out waiting for simulated location after re-init'
+          );
+        }
+        await navigationController.setDestination(destination);
+        await navigationController.startGuidance();
+        await navigationController.simulator.simulateLocationsAlongExistingRoute(
+          { speedMultiplier: 5 }
+        );
+
+        // Listen for turn-by-turn events in the second session
+        setOnTurnByTurn(async () => {
+          // Received navInfo after cleanup+reinit — test passes
+          setOnTurnByTurn(null);
+          await navigationController.cleanup();
+          passTest();
+        });
+      });
+
+      await initializeNavigation(navigationController, failTest);
+    }
+  });
+
+  setOnNavigationReady(async () => {
+    disableVoiceGuidanceForTests(navigationController);
+    navigationController.setTurnByTurnLoggingEnabled(true);
+
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
+    await navigationController.setDestination(destination);
+    await navigationController.startGuidance();
+    await navigationController.simulator.simulateLocationsAlongExistingRoute({
+      speedMultiplier: 5,
+    });
   });
 
   await initializeNavigation(navigationController, failTest);

--- a/ios/react-native-navigation-sdk/NavModule.mm
+++ b/ios/react-native-navigation-sdk/NavModule.mm
@@ -104,10 +104,14 @@ RCT_EXPORT_MODULE(NavModule);
   _session.started = YES;
 
   if (self->_session.navigator) {
+    // Remove any existing listener first to prevent duplicates
+    // in case initializeSession is called multiple times.
+    [self->_session.navigator removeListener:self];
     [self->_session.navigator addListener:self];
     self->_session.navigator.stopGuidanceAtArrival = NO;
   }
 
+  [self->_session.roadSnappedLocationProvider removeListener:self];
   [self->_session.roadSnappedLocationProvider addListener:self];
 
   NavViewModule *navViewModule = [NavViewModule sharedInstance];
@@ -277,6 +281,7 @@ RCT_EXPORT_MODULE(NavModule);
       [self->_session.roadSnappedLocationProvider removeListener:self];
     }
 
+    self.enableUpdateInfo = NO;
     self->_session.started = NO;
     self->_session = nil;
 

--- a/scripts/addlicense.sh
+++ b/scripts/addlicense.sh
@@ -26,4 +26,5 @@ addlicense -f header_template.txt $@ \
         --ignore "coverage/**" \
         --ignore ".yarn/**" \
         --ignore ".github/ISSUE_TEMPLATE/**" \
+        --ignore ".github/java-upgrade/**" \
         .


### PR DESCRIPTION
Fixes an issue where the navigation forwarding service was not stopped when `cleanup()` was called on Android, potentially causing the service to continue running in the background after the navigation session was terminated.
Also removes observers for navInfo events on both platforms.

Related issue #526

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/