### PR TITLE
fix: prevent crash when tapping marker without snippet on iOS

### DIFF
--- a/ios/react-native-navigation-sdk/NavView.mm
+++ b/ios/react-native-navigation-sdk/NavView.mm
@@ -338,7 +338,7 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps =
       marker.title != nil ? [marker.title UTF8String] : "",
       marker.opacity,
       marker.rotation,
-      [marker.snippet UTF8String],
+      marker.snippet != nil ? [marker.snippet UTF8String] : "",
       (int)marker.zIndex};
   self.eventEmitter.onMarkerInfoWindowTapped(result);
 }
@@ -350,7 +350,7 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps =
       marker.title != nil ? [marker.title UTF8String] : "",
       marker.opacity,
       marker.rotation,
-      [marker.snippet UTF8String],
+      marker.snippet != nil ? [marker.snippet UTF8String] : "",
       (int)marker.zIndex};
   self.eventEmitter.onMarkerClick(result);
 }


### PR DESCRIPTION
Adds nil guard on iOS implementaiton for `marker.snippet` in `handleMarkerClick:` and `handleMarkerInfoWindowTapped:` to prevent NULL pointer dereference crash when tapping markers without a snippet set.

Fixes #559

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/