### PR TITLE
feat!: upgrade Nav SDKs to Android 7.6.0 and iOS 10.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ const {
 | `setDestinations(destinations: Waypoint[], routingOptions?, displayOptions?)` | `Promise<RouteStatus>`             | Set navigation destinations                                                                |
 | `setDestination(waypoint: Waypoint, routingOptions?, displayOptions?)`        | `Promise<RouteStatus>`             | Set a single navigation destination                                                        |
 | `clearDestinations()`                                                         | `Promise<void>`                    | Clear all destinations                                                                     |
-| `continueToNextDestination()`                                                 | `Promise<void>`                    | Navigate to the next destination in the list                                               |
+| `continueToNextDestination()`                                                 | `Promise<ContinueToNextDestinationResponse>` | Navigate to the next destination in the list                                               |
 | `startGuidance()`                                                             | `Promise<void>`                    | Start turn-by-turn navigation guidance                                                     |
 | `stopGuidance()`                                                              | `Promise<void>`                    | Stop navigation guidance                                                                   |
 | `getCurrentTimeAndDistance()`                                                 | `Promise<TimeAndDistance \| null>` | Get time and distance to current destination                                               |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,6 +58,6 @@ dependencies {
   implementation "androidx.car.app:app:1.4.0"
   implementation "androidx.car.app:app-projected:1.4.0"
   implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-  implementation "com.google.android.libraries.navigation:navigation:7.5.0"
+  implementation "com.google.android.libraries.navigation:navigation:7.6.0"
   api 'com.google.guava:guava:31.0.1-android'
 }

--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -670,8 +670,14 @@ public class NavModule extends NativeNavModuleSpec
     if (!ensureNavigatorAvailable(promise)) {
       return;
     }
-    mNavigator.continueToNextDestination();
-    promise.resolve(true);
+    Waypoint nextWaypoint = mNavigator.continueToNextDestination();
+    WritableMap result = Arguments.createMap();
+    if (nextWaypoint != null) {
+      result.putMap("waypoint", ObjectTranslationUtil.getMapFromWaypoint(nextWaypoint));
+    } else {
+      result.putNull("waypoint");
+    }
+    promise.resolve(result);
   }
 
   @Override

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -153,7 +153,7 @@ dependencies {
     implementation "androidx.car.app:app-projected:1.4.0"
 
     // Include the Google Navigation SDK.
-    implementation 'com.google.android.libraries.navigation:navigation:7.5.0'
+    implementation 'com.google.android.libraries.navigation:navigation:7.6.0'
 }
 
 secrets {

--- a/example/src/controls/navigationControls.tsx
+++ b/example/src/controls/navigationControls.tsx
@@ -29,11 +29,14 @@ import {
   type CameraPosition,
   type NavigationController,
   type DisplayOptions,
-  RouteStatus,
 } from '@googlemaps/react-native-navigation-sdk';
 import SelectDropdown from 'react-native-select-dropdown';
 
 import { ControlStyles } from '../styles/components';
+import {
+  handleRouteStatus,
+  handleContinueToNextDestination,
+} from '../helpers/navigationUtils';
 
 export interface NavigationControlsProps {
   readonly navigationController: NavigationController;
@@ -105,35 +108,6 @@ const NavigationControls: React.FC<NavigationControlsProps> = ({
 
   const [latitude, onLatChanged] = useState('');
   const [longitude, onLngChanged] = useState('');
-
-  const handleRouteStatus = (routeStatus: RouteStatus) => {
-    switch (routeStatus) {
-      case RouteStatus.OK:
-        showSnackbar('Route created successfully');
-        break;
-      case RouteStatus.ROUTE_CANCELED:
-        Alert.alert('Error', 'Route Cancelled');
-        break;
-      case RouteStatus.NO_ROUTE_FOUND:
-        Alert.alert('Error', 'No Route Found');
-        break;
-      case RouteStatus.NETWORK_ERROR:
-        Alert.alert('Error', 'Network Error');
-        break;
-      case RouteStatus.LOCATION_DISABLED:
-        Alert.alert('Error', 'Location Disabled');
-        break;
-      case RouteStatus.LOCATION_UNKNOWN:
-        Alert.alert('Error', 'Location Unknown');
-        break;
-      case RouteStatus.DUPLICATE_WAYPOINTS_ERROR:
-        Alert.alert('Error', 'Consecutive duplicate waypoints are not allowed');
-        break;
-      default:
-        showSnackbar('Route status: ' + routeStatus);
-        Alert.alert('Error', 'Starting Guidance Error');
-    }
-  };
 
   const disposeNavigation = async () => {
     try {
@@ -222,8 +196,9 @@ const NavigationControls: React.FC<NavigationControlsProps> = ({
     onFollowingPerspectiveChange?.(_index);
   };
 
-  const continueToNextDestination = () => {
-    navigationController.continueToNextDestination();
+  const continueToNextDestination = async () => {
+    const response = await navigationController.continueToNextDestination();
+    await handleContinueToNextDestination(navigationController, response);
   };
 
   const startGuidance = () => {

--- a/example/src/helpers/navigationUtils.ts
+++ b/example/src/helpers/navigationUtils.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert } from 'react-native';
+import {
+  RouteStatus,
+  type NavigationController,
+  type ContinueToNextDestinationResponse,
+} from '@googlemaps/react-native-navigation-sdk';
+import { showSnackbar } from './snackbar';
+
+/**
+ * Handles a RouteStatus result from setDestinations or continueToNextDestination.
+ * Shows appropriate user feedback and returns whether the route was successful.
+ *
+ * @param routeStatus - The route status to handle.
+ * @returns true if the route status is OK, false otherwise.
+ */
+export const handleRouteStatus = (routeStatus: RouteStatus): boolean => {
+  switch (routeStatus) {
+    case RouteStatus.OK:
+      showSnackbar('Route created successfully');
+      return true;
+    case RouteStatus.ROUTE_CANCELED:
+      Alert.alert('Error', 'Route Cancelled');
+      return false;
+    case RouteStatus.NO_ROUTE_FOUND:
+      Alert.alert('Error', 'No Route Found');
+      return false;
+    case RouteStatus.NETWORK_ERROR:
+      Alert.alert('Error', 'Network Error');
+      return false;
+    case RouteStatus.LOCATION_DISABLED:
+      Alert.alert('Error', 'Location Disabled');
+      return false;
+    case RouteStatus.LOCATION_UNKNOWN:
+      Alert.alert('Error', 'Location Unknown');
+      return false;
+    case RouteStatus.DUPLICATE_WAYPOINTS_ERROR:
+      Alert.alert('Error', 'Consecutive duplicate waypoints are not allowed');
+      return false;
+    default:
+      showSnackbar('Route status: ' + routeStatus);
+      Alert.alert('Error', 'Starting Guidance Error');
+      return false;
+  }
+};
+
+/**
+ * Handles the response from continueToNextDestination.
+ *
+ * Checks the route status (if available, i.e. on iOS) and stops guidance
+ * on failure. Returns the response for further processing.
+ *
+ * @param navigationController - The navigation controller instance.
+ * @param response - The response from continueToNextDestination.
+ * @returns true if navigation can continue, false if it was aborted.
+ */
+export const handleContinueToNextDestination = async (
+  navigationController: NavigationController,
+  response: ContinueToNextDestinationResponse
+): Promise<boolean> => {
+  // If routeStatus is available (iOS), check for errors
+  if (response.routeStatus !== undefined) {
+    if (!handleRouteStatus(response.routeStatus)) {
+      await navigationController.stopGuidance();
+      return false;
+    }
+  }
+
+  if (response.waypoint === null) {
+    showSnackbar('No more waypoints remaining');
+    await navigationController.stopGuidance();
+    return false;
+  }
+
+  return true;
+};

--- a/example/src/screens/IntegrationTestsScreen.tsx
+++ b/example/src/screens/IntegrationTestsScreen.tsx
@@ -86,6 +86,7 @@ const IntegrationTestsScreen = () => {
     navigationController,
     setOnNavigationReady,
     setOnArrival,
+    setOnLocationChanged,
     setOnRemainingTimeOrDistanceChanged,
     setOnRouteChanged,
   } = useNavigation();
@@ -219,6 +220,7 @@ const IntegrationTestsScreen = () => {
       setOnArrival,
       setOnRemainingTimeOrDistanceChanged,
       setOnRouteChanged,
+      setOnLocationChanged,
       passTest,
       failTest,
       setDetoxStep,

--- a/example/src/screens/MultipleMapsScreen.tsx
+++ b/example/src/screens/MultipleMapsScreen.tsx
@@ -42,6 +42,7 @@ import {
 import MapsControls from '../controls/mapsControls';
 import NavigationControls from '../controls/navigationControls';
 import OverlayModal from '../helpers/overlayModal';
+import { handleContinueToNextDestination } from '../helpers/navigationUtils';
 import { showSnackbar } from '../helpers/snackbar';
 import { CommonStyles, ControlStyles } from '../styles/components';
 import { MapStylingOptions } from '../styles/mapStyling';
@@ -123,14 +124,19 @@ const MultipleMapsScreen = () => {
 
   // Set up callbacks that depend on navigationController
   useEffect(() => {
-    setOnArrival((event: ArrivalEvent) => {
+    setOnArrival(async (event: ArrivalEvent) => {
       if (event.isFinalDestination) {
         navigationController.stopGuidance();
+        showSnackbar('Arrived at final destination');
       } else {
-        navigationController.continueToNextDestination();
-        navigationController.startGuidance();
+        const response = await navigationController.continueToNextDestination();
+        if (
+          await handleContinueToNextDestination(navigationController, response)
+        ) {
+          navigationController.startGuidance();
+          showSnackbar('Arrived, continuing to next destination');
+        }
       }
-      showSnackbar('Arrived');
     });
 
     setOnRemainingTimeOrDistanceChanged(timeAndDistance => {

--- a/example/src/screens/NavigationScreen.tsx
+++ b/example/src/screens/NavigationScreen.tsx
@@ -46,6 +46,7 @@ import NavigationActionPath, {
   ActionPathStep,
 } from '../controls/NavigationActionPath';
 import OverlayModal from '../helpers/overlayModal';
+import { handleContinueToNextDestination } from '../helpers/navigationUtils';
 import { showSnackbar, Snackbar } from '../helpers/snackbar';
 import { CommonStyles, MapStyles } from '../styles/components';
 import { MapStylingOptions } from '../styles/mapStyling';
@@ -191,14 +192,19 @@ const NavigationScreen = () => {
 
   // Set up callbacks that depend on navigationController
   useEffect(() => {
-    setOnArrival((event: ArrivalEvent) => {
+    setOnArrival(async (event: ArrivalEvent) => {
       if (event.isFinalDestination) {
         navigationController.stopGuidance();
+        showSnackbar('Arrived at final destination');
       } else {
-        navigationController.continueToNextDestination();
-        navigationController.startGuidance();
+        const response = await navigationController.continueToNextDestination();
+        if (
+          await handleContinueToNextDestination(navigationController, response)
+        ) {
+          navigationController.startGuidance();
+          showSnackbar('Arrived, continuing to next destination');
+        }
       }
-      showSnackbar('Arrived');
     });
 
     setOnRemainingTimeOrDistanceChanged(timeAndDistance => {

--- a/example/src/screens/integration_tests/integration_test.ts
+++ b/example/src/screens/integration_tests/integration_test.ts
@@ -18,7 +18,11 @@ import {
   AudioGuidance,
   TravelMode,
   NavigationSessionStatus,
+  RouteStatus,
   type ArrivalEvent,
+  type ContinueToNextDestinationResponse,
+  type LatLng,
+  type Location,
   type MapViewController,
   type NavigationController,
   type NavigationViewController,
@@ -40,6 +44,9 @@ interface TestTools {
     listener: ((timeAndDistance: TimeAndDistance) => void) | null | undefined
   ) => void;
   setOnRouteChanged: (listener: (() => void) | null | undefined) => void;
+  setOnLocationChanged: (
+    listener: ((location: Location) => void) | null | undefined
+  ) => void;
   passTest: () => void;
   failTest: (message: string) => void;
   setDetoxStep: (stepNumber: number) => void;
@@ -169,6 +176,52 @@ const disableVoiceGuidanceForTests = (
   navigationController: NavigationController
 ) => {
   navigationController.setAudioGuidanceType(AudioGuidance.SILENT);
+};
+
+const LOCATION_THRESHOLD_METERS = 100;
+const LOCATION_WAIT_TIMEOUT_MS = 15000;
+
+const distanceBetween = (a: LatLng, b: LatLng): number => {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const R = 6371000;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+  const h =
+    sinDLat * sinDLat +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * sinDLng * sinDLng;
+  return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+};
+
+const simulateAndWaitForLocation = (
+  navigationController: NavigationController,
+  setOnLocationChanged: (
+    listener: ((location: Location) => void) | null | undefined
+  ) => void,
+  target: LatLng,
+  thresholdMeters = LOCATION_THRESHOLD_METERS,
+  timeoutMs = LOCATION_WAIT_TIMEOUT_MS
+): Promise<Location | null> => {
+  return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      setOnLocationChanged(null);
+      resolve(null);
+    }, timeoutMs);
+
+    setOnLocationChanged((location: Location) => {
+      if (distanceBetween(location, target) <= thresholdMeters) {
+        clearTimeout(timer);
+        setOnLocationChanged(null);
+        resolve(location);
+      }
+    });
+
+    // Ensure the road-snapped location provider is active so that
+    // onLocationChanged events are emitted for simulated locations.
+    navigationController.startUpdatingLocation();
+    navigationController.simulator.simulateLocation(target);
+  });
 };
 
 export const testNavigationSessionInitialization = async (
@@ -371,6 +424,7 @@ export const testNavigationToSingleDestination = async (
     navigationController,
     setOnNavigationReady,
     setOnArrival,
+    setOnLocationChanged,
     passTest,
     failTest,
   } = testTools;
@@ -380,12 +434,20 @@ export const testNavigationToSingleDestination = async (
     return;
   }
 
+  const startLocation: LatLng = { lat: 37.4195823, lng: -122.0799018 };
+
   setOnNavigationReady(async () => {
     disableVoiceGuidanceForTests(navigationController);
-    await navigationController.simulator.simulateLocation({
-      lat: 37.4195823,
-      lng: -122.0799018,
-    });
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
     await navigationController.setDestinations(
       [
         {
@@ -432,6 +494,7 @@ export const testNavigationToMultipleDestination = async (
     navigationController,
     setOnNavigationReady,
     setOnArrival,
+    setOnLocationChanged,
     passTest,
     failTest,
   } = testTools;
@@ -441,25 +504,36 @@ export const testNavigationToMultipleDestination = async (
     return;
   }
 
+  const startLocation: LatLng = {
+    lat: 37.79136614772824,
+    lng: -122.41565900473043,
+  };
+
   let onArrivalCount = 0;
   setOnNavigationReady(async () => {
     disableVoiceGuidanceForTests(navigationController);
-    await navigationController.simulator.simulateLocation({
-      lat: 37.4195823,
-      lng: -122.0799018,
-    });
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
     await navigationController.setDestinations(
       [
         {
           position: {
-            lat: 37.418761,
-            lng: -122.080484,
+            lat: 37.7917,
+            lng: -122.4142,
           },
         },
         {
           position: {
-            lat: 37.4177952,
-            lng: -122.0817198,
+            lat: 37.79196,
+            lng: -122.41253,
           },
         },
       ],
@@ -483,7 +557,7 @@ export const testNavigationToMultipleDestination = async (
       );
     }
     await navigationController.simulator.simulateLocationsAlongExistingRoute({
-      speedMultiplier: Platform.OS === 'ios' ? 5 : 10,
+      speedMultiplier: 5,
     });
   });
   setOnArrival(async () => {
@@ -492,9 +566,33 @@ export const testNavigationToMultipleDestination = async (
       navigationController.cleanup();
       return passTest();
     }
-    await navigationController.continueToNextDestination();
+    const response: ContinueToNextDestinationResponse =
+      await navigationController.continueToNextDestination();
+    if (!response.waypoint) {
+      return failTest(
+        'continueToNextDestination returned null waypoint when next destination exists'
+      );
+    }
+    if (
+      Platform.OS === 'ios' &&
+      !Object.values(RouteStatus).includes(response.routeStatus as RouteStatus)
+    ) {
+      return failTest(
+        `continueToNextDestination returned unexpected routeStatus on iOS: ${response.routeStatus}`
+      );
+    }
+    await navigationController.startGuidance();
+    const nextRouteSegments = await waitForCondition(
+      () => navigationController.getRouteSegments(),
+      segments => segments.length > 0
+    );
+    if (!nextRouteSegments) {
+      return failTest(
+        'Timed out waiting for route segments after continueToNextDestination'
+      );
+    }
     await navigationController.simulator.simulateLocationsAlongExistingRoute({
-      speedMultiplier: Platform.OS === 'ios' ? 5 : 10,
+      speedMultiplier: 5,
     });
   });
 
@@ -506,6 +604,7 @@ export const testRouteSegments = async (testTools: TestTools) => {
     navigationController,
     setOnNavigationReady,
     setOnArrival,
+    setOnLocationChanged,
     passTest,
     failTest,
     expectFalseError,
@@ -515,13 +614,23 @@ export const testRouteSegments = async (testTools: TestTools) => {
   if (!(await acceptToS(navigationController, failTest))) {
     return;
   }
+  const startLocation: LatLng = {
+    lat: 37.79136614772824,
+    lng: -122.41565900473043,
+  };
   let beginTraveledPath;
   setOnNavigationReady(async () => {
     disableVoiceGuidanceForTests(navigationController);
-    await navigationController.simulator.simulateLocation({
-      lat: 37.79136614772824,
-      lng: -122.41565900473043,
-    });
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
     await navigationController.setDestination({
       title: 'Grace Cathedral',
       position: {
@@ -569,6 +678,7 @@ export const testGetCurrentTimeAndDistance = async (testTools: TestTools) => {
     navigationController,
     setOnNavigationReady,
     setOnArrival,
+    setOnLocationChanged,
     passTest,
     failTest,
     expectFalseError,
@@ -579,13 +689,23 @@ export const testGetCurrentTimeAndDistance = async (testTools: TestTools) => {
     return;
   }
 
+  const startLocation: LatLng = {
+    lat: 37.79136614772824,
+    lng: -122.41565900473043,
+  };
   let beginTimeAndDistance: TimeAndDistance | null = null;
   setOnNavigationReady(async () => {
     disableVoiceGuidanceForTests(navigationController);
-    await navigationController.simulator.simulateLocation({
-      lat: 37.79136614772824,
-      lng: -122.41565900473043,
-    });
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
     await navigationController.setDestination({
       title: 'Grace Cathedral',
       position: {
@@ -1153,6 +1273,7 @@ export const testOnRemainingTimeOrDistanceChanged = async (
     navigationController,
     setOnNavigationReady,
     setOnRemainingTimeOrDistanceChanged,
+    setOnLocationChanged,
     passTest,
     failTest,
   } = testTools;
@@ -1161,6 +1282,11 @@ export const testOnRemainingTimeOrDistanceChanged = async (
   if (!(await acceptToS(navigationController, failTest))) {
     return;
   }
+
+  const startLocation: LatLng = {
+    lat: 37.79136614772824,
+    lng: -122.41565900473043,
+  };
 
   setOnRemainingTimeOrDistanceChanged(async timeAndDistance => {
     if (timeAndDistance.meters > 0 && timeAndDistance.seconds > 0) {
@@ -1171,10 +1297,16 @@ export const testOnRemainingTimeOrDistanceChanged = async (
 
   setOnNavigationReady(async () => {
     disableVoiceGuidanceForTests(navigationController);
-    await navigationController.simulator.simulateLocation({
-      lat: 37.79136614772824,
-      lng: -122.41565900473043,
-    });
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
     await navigationController.setDestination({
       title: 'Grace Cathedral',
       position: {
@@ -1206,6 +1338,7 @@ export const testOnArrival = async (testTools: TestTools) => {
     navigationController,
     setOnNavigationReady,
     setOnArrival,
+    setOnLocationChanged,
     passTest,
     failTest,
   } = testTools;
@@ -1215,16 +1348,27 @@ export const testOnArrival = async (testTools: TestTools) => {
     return;
   }
 
+  const startLocation: LatLng = {
+    lat: 37.79136614772824,
+    lng: -122.41565900473043,
+  };
+
   setOnArrival(async () => {
     navigationController.cleanup();
     passTest();
   });
   setOnNavigationReady(async () => {
     disableVoiceGuidanceForTests(navigationController);
-    await navigationController.simulator.simulateLocation({
-      lat: 37.79136614772824,
-      lng: -122.41565900473043,
-    });
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
     await navigationController.setDestination({
       title: 'Grace Cathedral',
       position: {
@@ -1255,6 +1399,7 @@ export const testOnRouteChanged = async (testTools: TestTools) => {
     navigationController,
     setOnNavigationReady,
     setOnRouteChanged,
+    setOnLocationChanged,
     passTest,
     failTest,
   } = testTools;
@@ -1263,16 +1408,26 @@ export const testOnRouteChanged = async (testTools: TestTools) => {
   if (!(await acceptToS(navigationController, failTest))) {
     return;
   }
+  const startLocation: LatLng = {
+    lat: 37.79136614772824,
+    lng: -122.41565900473043,
+  };
   setOnRouteChanged(async () => {
     navigationController.cleanup();
     passTest();
   });
   setOnNavigationReady(async () => {
     disableVoiceGuidanceForTests(navigationController);
-    await navigationController.simulator.simulateLocation({
-      lat: 37.79136614772824,
-      lng: -122.41565900473043,
-    });
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
     await navigationController.setDestination({
       title: 'Grace Cathedral',
       position: {

--- a/ios/react-native-navigation-sdk/NavModule.mm
+++ b/ios/react-native-navigation-sdk/NavModule.mm
@@ -415,8 +415,18 @@ RCT_EXPORT_MODULE(NavModule);
       return;
     }
 
-    [navigator continueToNextDestination];
-    resolve(@(YES));
+    [navigator continueToNextDestinationWithCompletion:^(GMSNavigationWaypoint *_Nullable waypoint,
+                                                         GMSRouteStatus routeStatus) {
+      NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
+      if (waypoint != nil) {
+        result[@"waypoint"] =
+            [ObjectTranslationUtil transformNavigationWaypointToDictionary:waypoint];
+      } else {
+        result[@"waypoint"] = [NSNull null];
+      }
+      result[@"routeStatus"] = [NavModule routeStatusToString:routeStatus];
+      resolve(result);
+    }];
   });
 }
 

--- a/react-native-navigation-sdk.podspec
+++ b/react-native-navigation-sdk.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.public_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency "GoogleNavigation", "10.10.0"
+  s.dependency "GoogleNavigation", "10.12.0"
 
   install_modules_dependencies(s)
 end

--- a/src/native/NativeNavModule.ts
+++ b/src/native/NativeNavModule.ts
@@ -101,6 +101,11 @@ type ArrivalEventSpec = Readonly<{
   isFinalDestination?: boolean;
 }>;
 
+type ContinueToNextDestinationResponseSpec = Readonly<{
+  waypoint: WaypointSpec | null;
+  routeStatus?: string;
+}>;
+
 type TimeAndDistanceSpec = Readonly<{
   delaySeverity: Double;
   meters: Double;
@@ -174,7 +179,7 @@ export interface Spec extends TurboModule {
     displayOptions: DisplayOptionsSpec,
     routeTokenOptions: RouteTokenOptionsSpec
   ): Promise<RouteStatusSpec>;
-  continueToNextDestination(): Promise<void>;
+  continueToNextDestination(): Promise<ContinueToNextDestinationResponseSpec>;
   clearDestinations(): Promise<void>;
   startGuidance(): Promise<void>;
   stopGuidance(): Promise<void>;

--- a/src/navigation/navigation/types.ts
+++ b/src/navigation/navigation/types.ts
@@ -181,6 +181,19 @@ export interface TermsAndConditionsDialogOptions {
 }
 
 /**
+ * Response returned by `continueToNextDestination()`.
+ */
+export interface ContinueToNextDestinationResponse {
+  /** The waypoint guidance is now heading to, or null if there are no more waypoints left. */
+  waypoint: Waypoint | null;
+  /**
+   * The route status indicating the result of routing to the next destination.
+   * Only available on iOS. On Android this will be `undefined`.
+   */
+  routeStatus?: RouteStatus;
+}
+
+/**
  * An event fired upon arrival at a destination.
  */
 export interface ArrivalEvent {
@@ -452,8 +465,11 @@ export interface NavigationController {
   /**
    * Proceeds to the next destination or waypoint within a predefined route.
    * Assumes that there is an ongoing route with multiple waypoints.
+   *
+   * @returns A promise that resolves with a `ContinueToNextDestinationResponse` containing
+   *          the next waypoint (or null if no more waypoints) and, on iOS, the route status.
    */
-  continueToNextDestination(): Promise<void>;
+  continueToNextDestination(): Promise<ContinueToNextDestinationResponse>;
 
   /**
    * Clears all previously set destinations or waypoints from the map, effectively

--- a/src/navigation/navigation/useNavigationController.ts
+++ b/src/navigation/navigation/useNavigationController.ts
@@ -39,6 +39,7 @@ import {
   type SpeedAlertOptions,
   type LocationSimulationOptions,
   type ArrivalEvent,
+  type ContinueToNextDestinationResponse,
 } from './types';
 
 const { NavModule } = NativeModules;
@@ -444,9 +445,16 @@ export const useNavigationController = (
         return await setDestinationsImpl(waypoints, options);
       },
 
-      continueToNextDestination: async () => {
-        return await NavModule.continueToNextDestination();
-      },
+      continueToNextDestination:
+        async (): Promise<ContinueToNextDestinationResponse> => {
+          const result = await NavModule.continueToNextDestination();
+          return {
+            waypoint: result.waypoint ?? null,
+            routeStatus: result.routeStatus
+              ? (result.routeStatus as RouteStatus)
+              : undefined,
+          };
+        },
 
       clearDestinations: async () => {
         return await NavModule.clearDestinations();


### PR DESCRIPTION
- Upgrades Google Maps Navigation SDK for Android to version 7.6.0
- Upgrades Google Maps Navigation SDK for iOS to version 10.12.0

BREAKING CHANGE: `continueToNextDestination()` now returns `ContinueToNextDestinationResponse` containing `waypoint` and `routeStatus` instead of `void`

Android SDK version 7.6.0 release notes are available at:
https://developers.google.com/maps/documentation/navigation/android-sdk/release-notes

iOS SDK version 10.12.0 release notes are available at:
https://developers.google.com/maps/documentation/navigation/ios-sdk/release-notes

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/