### PR TITLE
fix: prevent crash on min/max zoom changes and fix zoom on navigation

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
@@ -1039,7 +1039,7 @@ public class MapViewController implements INavigationViewControllerProperties {
   }
 
   @SuppressLint("MissingPermission")
-  public void setFollowingPerspective(int jsValue, float zoomLevel) {
+  public void setFollowingPerspective(int jsValue, Float zoomLevel) {
     if (mGoogleMap == null) {
       return;
     }
@@ -1047,7 +1047,7 @@ public class MapViewController implements INavigationViewControllerProperties {
     @CameraPerspective
     int perspective = EnumTranslationUtil.getCameraPerspectiveFromJsValue(jsValue);
 
-    if (zoomLevel >= 0.0f) {
+    if (zoomLevel != null) {
       FollowMyLocationOptions options =
           FollowMyLocationOptions.builder().setZoomLevel(zoomLevel).build();
       mGoogleMap.followMyLocation(perspective, options);

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
@@ -15,15 +15,18 @@ package com.google.android.react.navsdk;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.util.Log;
 import androidx.core.util.Supplier;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.GoogleMap.CameraPerspective;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.CircleOptions;
+import com.google.android.gms.maps.model.FollowMyLocationOptions;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.GroundOverlayOptions;
 import com.google.android.gms.maps.model.LatLng;
@@ -42,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 
 public class MapViewController implements INavigationViewControllerProperties {
+  private static final String TAG = "MapViewController";
   private GoogleMap mGoogleMap;
   private Supplier<Activity> activitySupplier;
   private INavigationViewCallback mNavigationViewCallback;
@@ -883,23 +887,35 @@ public class MapViewController implements INavigationViewControllerProperties {
       return;
     }
 
-    // Get the effective max zoom for comparison
-    float maxZoom =
+    minZoomLevelPreference = minZoomLevel;
+
+    // Reset both preferences first so the new min/max pair is always applied
+    // atomically. Without this, Fabric can deliver minZoomLevel and maxZoomLevel
+    // prop updates in any order, causing a transient state where min > max.
+    mGoogleMap.resetMinMaxZoomPreference();
+
+    float effectiveMin = (minZoomLevel < 0.0f) ? mGoogleMap.getMinZoomLevel() : minZoomLevel;
+    float effectiveMax =
         (maxZoomLevelPreference != null && maxZoomLevelPreference >= 0.0f)
             ? maxZoomLevelPreference
             : mGoogleMap.getMaxZoomLevel();
 
-    // Validate that min is not greater than max (unless using -1 sentinel)
-    if (minZoomLevel >= 0.0f && minZoomLevel > maxZoom) {
-      throw new IllegalArgumentException(
-          "Minimum zoom level cannot be greater than maximum zoom level");
+    if (effectiveMin > effectiveMax) {
+      Log.w(
+          TAG,
+          "minZoomLevel ("
+              + effectiveMin
+              + ") is greater than maxZoomLevel ("
+              + effectiveMax
+              + "). Ignoring zoom level constraints.");
+      return;
     }
 
-    minZoomLevelPreference = minZoomLevel;
-
-    // Use map's current minZoomLevel if -1 is provided
-    float effectiveMin = (minZoomLevel < 0.0f) ? mGoogleMap.getMinZoomLevel() : minZoomLevel;
     mGoogleMap.setMinZoomPreference(effectiveMin);
+
+    if (maxZoomLevelPreference != null) {
+      mGoogleMap.setMaxZoomPreference(effectiveMax);
+    }
   }
 
   @Override
@@ -908,23 +924,35 @@ public class MapViewController implements INavigationViewControllerProperties {
       return;
     }
 
-    // Get the effective min zoom for comparison
-    float minZoom =
+    maxZoomLevelPreference = maxZoomLevel;
+
+    // Reset both preferences first so the new min/max pair is always applied
+    // atomically. Without this, Fabric can deliver minZoomLevel and maxZoomLevel
+    // prop updates in any order, causing a transient state where min > max.
+    mGoogleMap.resetMinMaxZoomPreference();
+
+    float effectiveMax = (maxZoomLevel < 0.0f) ? mGoogleMap.getMaxZoomLevel() : maxZoomLevel;
+    float effectiveMin =
         (minZoomLevelPreference != null && minZoomLevelPreference >= 0.0f)
             ? minZoomLevelPreference
             : mGoogleMap.getMinZoomLevel();
 
-    // Validate that max is not less than min (unless using -1 sentinel)
-    if (maxZoomLevel >= 0.0f && maxZoomLevel < minZoom) {
-      throw new IllegalArgumentException(
-          "Maximum zoom level cannot be less than minimum zoom level");
+    if (effectiveMin > effectiveMax) {
+      Log.w(
+          TAG,
+          "minZoomLevel ("
+              + effectiveMin
+              + ") is greater than maxZoomLevel ("
+              + effectiveMax
+              + "). Ignoring zoom level constraints.");
+      return;
     }
 
-    maxZoomLevelPreference = maxZoomLevel;
-
-    // Use map's current maxZoomLevel if -1 is provided
-    float effectiveMax = (maxZoomLevel < 0.0f) ? mGoogleMap.getMaxZoomLevel() : maxZoomLevel;
     mGoogleMap.setMaxZoomPreference(effectiveMax);
+
+    if (minZoomLevelPreference != null) {
+      mGoogleMap.setMinZoomPreference(effectiveMin);
+    }
   }
 
   public void setZoomGesturesEnabled(boolean enabled) {
@@ -1005,16 +1033,27 @@ public class MapViewController implements INavigationViewControllerProperties {
       return;
     }
 
+    minZoomLevelPreference = null;
+    maxZoomLevelPreference = null;
     mGoogleMap.resetMinMaxZoomPreference();
   }
 
   @SuppressLint("MissingPermission")
-  public void setFollowingPerspective(int jsValue) {
+  public void setFollowingPerspective(int jsValue, float zoomLevel) {
     if (mGoogleMap == null) {
       return;
     }
 
-    mGoogleMap.followMyLocation(EnumTranslationUtil.getCameraPerspectiveFromJsValue(jsValue));
+    @CameraPerspective
+    int perspective = EnumTranslationUtil.getCameraPerspectiveFromJsValue(jsValue);
+
+    if (zoomLevel >= 0.0f) {
+      FollowMyLocationOptions options =
+          FollowMyLocationOptions.builder().setZoomLevel(zoomLevel).build();
+      mGoogleMap.followMyLocation(perspective, options);
+    } else {
+      mGoogleMap.followMyLocation(perspective);
+    }
   }
 
   public void setPadding(int top, int left, int bottom, int right) {

--- a/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
@@ -393,14 +393,15 @@ public class NavAutoModule extends NativeNavAutoModuleSpec
   }
 
   @Override
-  public void setFollowingPerspective(double perspective) {
+  public void setFollowingPerspective(double perspective, double zoomLevel) {
     int jsValue = (int) perspective;
+    float zoom = (float) zoomLevel;
     UiThreadUtil.runOnUiThread(
         () -> {
           if (mMapViewController == null) {
             return;
           }
-          mMapViewController.setFollowingPerspective(jsValue);
+          mMapViewController.setFollowingPerspective(jsValue, zoom);
         });
   }
 

--- a/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
@@ -393,15 +393,15 @@ public class NavAutoModule extends NativeNavAutoModuleSpec
   }
 
   @Override
-  public void setFollowingPerspective(double perspective, double zoomLevel) {
+  public void setFollowingPerspective(double perspective, Double zoomLevel) {
     int jsValue = (int) perspective;
-    float zoom = (float) zoomLevel;
     UiThreadUtil.runOnUiThread(
         () -> {
           if (mMapViewController == null) {
             return;
           }
-          mMapViewController.setFollowingPerspective(jsValue, zoom);
+          mMapViewController.setFollowingPerspective(
+              jsValue, zoomLevel == null ? null : zoomLevel.floatValue());
         });
   }
 

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewModule.java
@@ -405,7 +405,8 @@ public class NavViewModule extends NativeNavViewModuleSpec {
   }
 
   @Override
-  public void setFollowingPerspective(String nativeID, double perspective, final Promise promise) {
+  public void setFollowingPerspective(
+      String nativeID, double perspective, double zoomLevel, final Promise promise) {
     UiThreadUtil.runOnUiThread(
         () -> {
           IMapViewFragment fragment = mNavViewManager.getFragmentByNativeId(nativeID);
@@ -415,7 +416,9 @@ public class NavViewModule extends NativeNavViewModuleSpec {
           }
 
           if (fragment instanceof INavViewFragment) {
-            fragment.getMapController().setFollowingPerspective((int) perspective);
+            fragment
+                .getMapController()
+                .setFollowingPerspective((int) perspective, (float) zoomLevel);
             promise.resolve(null);
           } else {
             promise.reject(JsErrors.NOT_NAV_VIEW_ERROR_CODE, JsErrors.NOT_NAV_VIEW_ERROR_MESSAGE);

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewModule.java
@@ -406,7 +406,7 @@ public class NavViewModule extends NativeNavViewModuleSpec {
 
   @Override
   public void setFollowingPerspective(
-      String nativeID, double perspective, double zoomLevel, final Promise promise) {
+      String nativeID, double perspective, Double zoomLevel, final Promise promise) {
     UiThreadUtil.runOnUiThread(
         () -> {
           IMapViewFragment fragment = mNavViewManager.getFragmentByNativeId(nativeID);
@@ -418,7 +418,8 @@ public class NavViewModule extends NativeNavViewModuleSpec {
           if (fragment instanceof INavViewFragment) {
             fragment
                 .getMapController()
-                .setFollowingPerspective((int) perspective, (float) zoomLevel);
+                .setFollowingPerspective(
+                    (int) perspective, zoomLevel == null ? null : zoomLevel.floatValue());
             promise.resolve(null);
           } else {
             promise.reject(JsErrors.NOT_NAV_VIEW_ERROR_CODE, JsErrors.NOT_NAV_VIEW_ERROR_MESSAGE);

--- a/example/e2e/map.test.js
+++ b/example/e2e/map.test.js
@@ -89,4 +89,11 @@ describe('Map view tests', () => {
     await expectNoErrors();
     await expectSuccess();
   });
+
+  it('MT10 - test min and max zoom level constraints', async () => {
+    await selectTestByName('testMinMaxZoomLevels');
+    await waitForTestToFinish();
+    await expectNoErrors();
+    await expectSuccess();
+  });
 });

--- a/example/e2e/navigation.test.js
+++ b/example/e2e/navigation.test.js
@@ -90,4 +90,12 @@ describe('Navigation tests', () => {
     await expectNoErrors();
     await expectSuccess();
   });
+
+  it('NT09 - test setFollowingPerspective with zoom level options', async () => {
+    await selectTestByName('testSetFollowingPerspective');
+    await agreeToTermsAndConditions();
+    await waitForTestToFinish();
+    await expectNoErrors();
+    await expectSuccess();
+  });
 });

--- a/example/src/screens/IntegrationTestsScreen.tsx
+++ b/example/src/screens/IntegrationTestsScreen.tsx
@@ -55,6 +55,7 @@ import {
   testStartGuidanceWithoutDestinations,
   testRouteTokenOptionsValidation,
   testMapStyle,
+  testMinMaxZoomLevels,
   NO_ERRORS_DETECTED_LABEL,
 } from './integration_tests/integration_test';
 
@@ -127,6 +128,12 @@ const IntegrationTestsScreen = () => {
     boolean | undefined
   >(undefined);
   const [mapStyle, setMapStyle] = useState<string | undefined>(undefined);
+  const [minZoomLevel, setMinZoomLevel] = useState<number | undefined>(
+    undefined
+  );
+  const [maxZoomLevel, setMaxZoomLevel] = useState<number | undefined>(
+    undefined
+  );
 
   const onMapReady = useCallback(async () => {
     try {
@@ -236,6 +243,8 @@ const IntegrationTestsScreen = () => {
       setZoomControlsEnabled,
       setMapToolbarEnabled,
       setMapStyle,
+      setMinZoomLevel,
+      setMaxZoomLevel,
     };
   };
 
@@ -305,6 +314,9 @@ const IntegrationTestsScreen = () => {
       case 'testMapStyle':
         await testMapStyle(getTestTools());
         break;
+      case 'testMinMaxZoomLevels':
+        await testMinMaxZoomLevels(getTestTools());
+        break;
       default:
         resetTestState();
         break;
@@ -347,6 +359,8 @@ const IntegrationTestsScreen = () => {
           zoomControlsEnabled={zoomControlsEnabled}
           mapToolbarEnabled={mapToolbarEnabled}
           mapStyle={mapStyle}
+          minZoomLevel={minZoomLevel}
+          maxZoomLevel={maxZoomLevel}
         />
       </View>
       <View style={{ flex: 4 }}>
@@ -517,6 +531,13 @@ const IntegrationTestsScreen = () => {
             runTest('testMapStyle');
           }}
           testID="testMapStyle"
+        />
+        <ExampleAppButton
+          title="testMinMaxZoomLevels"
+          onPress={() => {
+            runTest('testMinMaxZoomLevels');
+          }}
+          testID="testMinMaxZoomLevels"
         />
       </OverlayModal>
     </View>

--- a/example/src/screens/IntegrationTestsScreen.tsx
+++ b/example/src/screens/IntegrationTestsScreen.tsx
@@ -56,6 +56,7 @@ import {
   testRouteTokenOptionsValidation,
   testMapStyle,
   testMinMaxZoomLevels,
+  testSetFollowingPerspective,
   NO_ERRORS_DETECTED_LABEL,
 } from './integration_tests/integration_test';
 
@@ -317,6 +318,9 @@ const IntegrationTestsScreen = () => {
       case 'testMinMaxZoomLevels':
         await testMinMaxZoomLevels(getTestTools());
         break;
+      case 'testSetFollowingPerspective':
+        await testSetFollowingPerspective(getTestTools());
+        break;
       default:
         resetTestState();
         break;
@@ -538,6 +542,13 @@ const IntegrationTestsScreen = () => {
             runTest('testMinMaxZoomLevels');
           }}
           testID="testMinMaxZoomLevels"
+        />
+        <ExampleAppButton
+          title="testSetFollowingPerspective"
+          onPress={() => {
+            runTest('testSetFollowingPerspective');
+          }}
+          testID="testSetFollowingPerspective"
         />
       </OverlayModal>
     </View>

--- a/example/src/screens/integration_tests/integration_test.ts
+++ b/example/src/screens/integration_tests/integration_test.ts
@@ -16,6 +16,7 @@
 
 import {
   AudioGuidance,
+  CameraPerspective,
   TravelMode,
   NavigationSessionStatus,
   RouteStatus,
@@ -1771,4 +1772,97 @@ export const testMinMaxZoomLevels = async (testTools: TestTools) => {
   } catch (error) {
     failTest(`testMinMaxZoomLevels failed: ${error}`);
   }
+};
+
+export const testSetFollowingPerspective = async (testTools: TestTools) => {
+  const {
+    navigationController,
+    mapViewController,
+    navigationViewController,
+    setOnNavigationReady,
+    setOnLocationChanged,
+    passTest,
+    failTest,
+    expectFalseError,
+  } = testTools;
+
+  // Accept ToS first
+  if (!(await acceptToS(navigationController, failTest))) {
+    return;
+  }
+
+  const startLocation: LatLng = { lat: 37.4195823, lng: -122.0799018 };
+
+  setOnNavigationReady(async () => {
+    disableVoiceGuidanceForTests(navigationController);
+    const located = await simulateAndWaitForLocation(
+      navigationController,
+      setOnLocationChanged,
+      startLocation
+    );
+    if (!located) {
+      return failTest(
+        'Timed out waiting for simulated location to be confirmed'
+      );
+    }
+
+    if (!navigationViewController) {
+      return failTest('navigationViewController was expected to exist');
+    }
+
+    if (!mapViewController) {
+      return failTest('mapViewController was expected to exist');
+    }
+
+    try {
+      // Test 1: Set following perspective without zoom (default behavior)
+      await navigationViewController.setFollowingPerspective(
+        CameraPerspective.TILTED
+      );
+
+      // Test 2: Set following perspective with a fixed zoom level
+      await navigationViewController.setFollowingPerspective(
+        CameraPerspective.TOP_DOWN_NORTH_UP,
+        { zoomLevel: 15 }
+      );
+
+      const posAfterZoom15 = await waitForCondition(
+        () => mapViewController.getCameraPosition(),
+        pos => Math.abs((pos.zoom ?? 0) - 15) <= 0.5
+      );
+      if (!posAfterZoom15) {
+        return expectFalseError(
+          'Timed out waiting for zoom ~15 after setFollowingPerspective'
+        );
+      }
+
+      // Test 3: Set following perspective with a different zoom level
+      await navigationViewController.setFollowingPerspective(
+        CameraPerspective.TOP_DOWN_HEADING_UP,
+        { zoomLevel: 10 }
+      );
+
+      const posAfterZoom10 = await waitForCondition(
+        () => mapViewController.getCameraPosition(),
+        pos => Math.abs((pos.zoom ?? 0) - 10) <= 0.5
+      );
+      if (!posAfterZoom10) {
+        return expectFalseError(
+          'Timed out waiting for zoom ~10 after setFollowingPerspective'
+        );
+      }
+
+      // Test 4: Reset zoom by omitting options (should use default auto-zoom)
+      await navigationViewController.setFollowingPerspective(
+        CameraPerspective.TILTED
+      );
+
+      navigationController.cleanup();
+      passTest();
+    } catch (error) {
+      failTest(`testSetFollowingPerspective failed: ${error}`);
+    }
+  });
+
+  await initializeNavigation(navigationController, failTest);
 };

--- a/example/src/screens/integration_tests/integration_test.ts
+++ b/example/src/screens/integration_tests/integration_test.ts
@@ -64,6 +64,8 @@ interface TestTools {
   setZoomControlsEnabled: (enabled: boolean | undefined) => void;
   setMapToolbarEnabled: (enabled: boolean | undefined) => void;
   setMapStyle: (style: string | undefined) => void;
+  setMinZoomLevel: (level: number | undefined) => void;
+  setMaxZoomLevel: (level: number | undefined) => void;
 }
 
 const NAVIGATOR_NOT_READY_ERROR_CODE = 'NO_NAVIGATOR_ERROR_CODE';
@@ -1665,5 +1667,108 @@ export const testMapStyle = async (testTools: TestTools) => {
     passTest();
   } catch (error) {
     failTest(`Failed to set mapStyle: ${error}`);
+  }
+};
+
+export const testMinMaxZoomLevels = async (testTools: TestTools) => {
+  const {
+    mapViewController,
+    passTest,
+    failTest,
+    expectFalseError,
+    setMinZoomLevel,
+    setMaxZoomLevel,
+  } = testTools;
+
+  if (!mapViewController) {
+    return failTest('mapViewController was expected to exist');
+  }
+
+  try {
+    // Test 1: Set valid min and max zoom levels (min < max)
+    setMinZoomLevel(5);
+    setMaxZoomLevel(15);
+    await delay(200);
+
+    // Verify camera zoom is constrained - move to zoom below min
+    mapViewController.moveCamera({
+      target: { lat: 37.7749, lng: -122.4194 },
+      bearing: 0,
+      tilt: 0,
+      zoom: 3,
+    });
+    await delay(200);
+
+    const posAfterMinClamp = await mapViewController.getCameraPosition();
+    if ((posAfterMinClamp.zoom ?? 0) < 5) {
+      return expectFalseError(
+        `zoom (${posAfterMinClamp.zoom}) should be >= minZoomLevel (5)`
+      );
+    }
+
+    // Move to zoom above max
+    mapViewController.moveCamera({
+      target: { lat: 37.7749, lng: -122.4194 },
+      bearing: 0,
+      tilt: 0,
+      zoom: 20,
+    });
+    await delay(200);
+
+    const posAfterMaxClamp = await mapViewController.getCameraPosition();
+    if ((posAfterMaxClamp.zoom ?? 0) > 15) {
+      return expectFalseError(
+        `zoom (${posAfterMaxClamp.zoom}) should be <= maxZoomLevel (15)`
+      );
+    }
+
+    // Test 2: Set zoom within range - should work normally
+    mapViewController.moveCamera({
+      target: { lat: 37.7749, lng: -122.4194 },
+      bearing: 0,
+      tilt: 0,
+      zoom: 10,
+    });
+    await delay(200);
+
+    const posInRange = await mapViewController.getCameraPosition();
+    if (posInRange.zoom !== 10) {
+      return expectFalseError(
+        `zoom (${posInRange.zoom}) should be 10 when within range`
+      );
+    }
+
+    // Test 3: Reset zoom levels
+    setMinZoomLevel(undefined);
+    setMaxZoomLevel(undefined);
+    await delay(200);
+
+    // Test 4: Invalid case - min > max (should not crash, constraints ignored)
+    setMinZoomLevel(15);
+    setMaxZoomLevel(5);
+    await delay(200);
+
+    // Verify app did not crash - camera operations should still work
+    mapViewController.moveCamera({
+      target: { lat: 37.7749, lng: -122.4194 },
+      bearing: 0,
+      tilt: 0,
+      zoom: 10,
+    });
+    await delay(200);
+
+    const posAfterInvalid = await mapViewController.getCameraPosition();
+    if (!posAfterInvalid) {
+      return failTest('getCameraPosition failed after invalid min/max zoom');
+    }
+
+    // Clean up - reset to defaults
+    setMinZoomLevel(undefined);
+    setMaxZoomLevel(undefined);
+    await delay(200);
+
+    passTest();
+  } catch (error) {
+    failTest(`testMinMaxZoomLevels failed: ${error}`);
   }
 };

--- a/ios/react-native-navigation-sdk/NavAutoModule.mm
+++ b/ios/react-native-navigation-sdk/NavAutoModule.mm
@@ -548,11 +548,11 @@ static NavAutoModuleReadyCallback _navAutoModuleReadyCallback;
   });
 }
 
-- (void)setFollowingPerspective:(NSInteger)perspective zoomLevel:(double)zoomLevel {
+- (void)setFollowingPerspective:(NSInteger)perspective zoomLevel:(NSNumber *)zoomLevel {
   dispatch_async(dispatch_get_main_queue(), ^{
     if (self->_viewController) {
       [self->_viewController setFollowingPerspective:[NSNumber numberWithInteger:perspective]
-                                           zoomLevel:(float)zoomLevel];
+                                           zoomLevel:zoomLevel];
     }
   });
 }

--- a/ios/react-native-navigation-sdk/NavAutoModule.mm
+++ b/ios/react-native-navigation-sdk/NavAutoModule.mm
@@ -548,10 +548,11 @@ static NavAutoModuleReadyCallback _navAutoModuleReadyCallback;
   });
 }
 
-- (void)setFollowingPerspective:(NSInteger)perspective {
+- (void)setFollowingPerspective:(NSInteger)perspective zoomLevel:(double)zoomLevel {
   dispatch_async(dispatch_get_main_queue(), ^{
     if (self->_viewController) {
-      [self->_viewController setFollowingPerspective:[NSNumber numberWithInteger:perspective]];
+      [self->_viewController setFollowingPerspective:[NSNumber numberWithInteger:perspective]
+                                           zoomLevel:(float)zoomLevel];
     }
   });
 }

--- a/ios/react-native-navigation-sdk/NavViewController.h
+++ b/ios/react-native-navigation-sdk/NavViewController.h
@@ -45,7 +45,7 @@ typedef void (^OnArrayResult)(NSArray *_Nullable result);
 - (void)setReportIncidentButtonEnabled:(BOOL)isEnabled;
 - (void)setNavigationUIEnabled:(BOOL)isEnabled;
 - (void)setNavigationUIEnabledPreference:(int)preference;
-- (void)setFollowingPerspective:(NSNumber *)index;
+- (void)setFollowingPerspective:(NSNumber *)index zoomLevel:(float)zoomLevel;
 - (void)setNightMode:(NSNumber *)index;
 - (void)setSpeedometerEnabled:(BOOL)isEnabled;
 - (void)setSpeedLimitIconEnabled:(BOOL)isEnabled;

--- a/ios/react-native-navigation-sdk/NavViewController.h
+++ b/ios/react-native-navigation-sdk/NavViewController.h
@@ -45,7 +45,7 @@ typedef void (^OnArrayResult)(NSArray *_Nullable result);
 - (void)setReportIncidentButtonEnabled:(BOOL)isEnabled;
 - (void)setNavigationUIEnabled:(BOOL)isEnabled;
 - (void)setNavigationUIEnabledPreference:(int)preference;
-- (void)setFollowingPerspective:(NSNumber *)index zoomLevel:(float)zoomLevel;
+- (void)setFollowingPerspective:(NSNumber *)index zoomLevel:(NSNumber *)zoomLevel;
 - (void)setNightMode:(NSNumber *)index;
 - (void)setSpeedometerEnabled:(BOOL)isEnabled;
 - (void)setSpeedLimitIconEnabled:(BOOL)isEnabled;

--- a/ios/react-native-navigation-sdk/NavViewController.mm
+++ b/ios/react-native-navigation-sdk/NavViewController.mm
@@ -560,7 +560,7 @@
   _mapView.myLocationEnabled = isEnabled;
 }
 
-- (void)setFollowingPerspective:(NSNumber *)index {
+- (void)setFollowingPerspective:(NSNumber *)index zoomLevel:(float)zoomLevel {
   if ([index isEqual:@1]) {
     [_mapView setFollowingPerspective:GMSNavigationCameraPerspectiveTopDownNorthUp];
   } else if ([index isEqual:@2]) {
@@ -568,6 +568,13 @@
   } else {
     [_mapView setFollowingPerspective:GMSNavigationCameraPerspectiveTilted];
   }
+
+  if (zoomLevel >= 0.0f) {
+    _mapView.followingZoomLevel = zoomLevel;
+  } else {
+    _mapView.followingZoomLevel = GMSNavigationNoFollowingZoomLevel;
+  }
+
   _mapView.cameraMode = GMSNavigationCameraModeFollowing;
 }
 
@@ -950,6 +957,14 @@
   // Use default values if -1 is provided
   float effectiveMinLevel = (minLevel < 0.0f) ? kGMSMinZoomLevel : minLevel;
   float effectiveMaxLevel = (maxLevel < 0.0f) ? kGMSMaxZoomLevel : maxLevel;
+
+  if (effectiveMinLevel > effectiveMaxLevel) {
+    NSLog(@"NavViewController: minZoomLevel (%f) is greater than maxZoomLevel (%f). Ignoring zoom "
+          @"level constraints.",
+          effectiveMinLevel, effectiveMaxLevel);
+    return;
+  }
+
   [_mapView setMinZoom:effectiveMinLevel maxZoom:effectiveMaxLevel];
 }
 

--- a/ios/react-native-navigation-sdk/NavViewController.mm
+++ b/ios/react-native-navigation-sdk/NavViewController.mm
@@ -560,7 +560,9 @@
   _mapView.myLocationEnabled = isEnabled;
 }
 
-- (void)setFollowingPerspective:(NSNumber *)index zoomLevel:(float)zoomLevel {
+- (void)setFollowingPerspective:(NSNumber *)index zoomLevel:(NSNumber *)zoomLevel {
+  _mapView.cameraMode = GMSNavigationCameraModeFollowing;
+
   if ([index isEqual:@1]) {
     [_mapView setFollowingPerspective:GMSNavigationCameraPerspectiveTopDownNorthUp];
   } else if ([index isEqual:@2]) {
@@ -569,13 +571,11 @@
     [_mapView setFollowingPerspective:GMSNavigationCameraPerspectiveTilted];
   }
 
-  if (zoomLevel >= 0.0f) {
-    _mapView.followingZoomLevel = zoomLevel;
+  if (zoomLevel != nil) {
+    _mapView.followingZoomLevel = zoomLevel.floatValue;
   } else {
     _mapView.followingZoomLevel = GMSNavigationNoFollowingZoomLevel;
   }
-
-  _mapView.cameraMode = GMSNavigationCameraModeFollowing;
 }
 
 - (void)setSpeedometerEnabled:(BOOL)isEnabled {

--- a/ios/react-native-navigation-sdk/NavViewModule.mm
+++ b/ios/react-native-navigation-sdk/NavViewModule.mm
@@ -477,12 +477,13 @@ static NavViewModule *sharedInstance = nil;
 
 - (void)setFollowingPerspective:(NSString *)nativeID
                     perspective:(double)perspective
+                      zoomLevel:(double)zoomLevel
                         resolve:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject {
   NavViewController *viewController = [self getViewControllerForNativeID:nativeID];
   if (viewController) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [viewController setFollowingPerspective:@((NSInteger)perspective)];
+      [viewController setFollowingPerspective:@((NSInteger)perspective) zoomLevel:(float)zoomLevel];
       resolve(nil);
     });
   } else {

--- a/ios/react-native-navigation-sdk/NavViewModule.mm
+++ b/ios/react-native-navigation-sdk/NavViewModule.mm
@@ -476,14 +476,14 @@ static NavViewModule *sharedInstance = nil;
 }
 
 - (void)setFollowingPerspective:(NSString *)nativeID
-                    perspective:(double)perspective
-                      zoomLevel:(double)zoomLevel
+                    perspective:(NSInteger)perspective
+                      zoomLevel:(NSNumber *)zoomLevel
                         resolve:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject {
   NavViewController *viewController = [self getViewControllerForNativeID:nativeID];
   if (viewController) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [viewController setFollowingPerspective:@((NSInteger)perspective) zoomLevel:(float)zoomLevel];
+      [viewController setFollowingPerspective:@(perspective) zoomLevel:zoomLevel];
       resolve(nil);
     });
   } else {

--- a/src/auto/types.ts
+++ b/src/auto/types.ts
@@ -15,7 +15,11 @@
  */
 
 import type { MapViewController, MapType, MapColorScheme } from '../maps';
-import type { CameraPerspective, NavigationNightMode } from '../navigation';
+import type {
+  CameraPerspective,
+  FollowMyLocationOptions,
+  NavigationNightMode,
+} from '../navigation';
 
 /** Defines all callbacks to be emitted by NavViewAuto support. */
 export interface NavigationAutoCallbacks {
@@ -63,8 +67,12 @@ export interface MapViewAutoController extends MapViewController {
    * camera following mode. This recenters the camera to follow the user's location.
    *
    * @param perspective The camera perspective to use when following.
+   * @param options Optional settings for camera follow behavior (e.g., fixed zoom level).
    */
-  setFollowingPerspective(perspective: CameraPerspective): void;
+  setFollowingPerspective(
+    perspective: CameraPerspective,
+    options?: FollowMyLocationOptions
+  ): void;
 
   /**
    * Sends a custom message from React Native to the native auto module.

--- a/src/auto/useNavigationAuto.ts
+++ b/src/auto/useNavigationAuto.ts
@@ -170,8 +170,7 @@ export const useNavigationAuto = (): UseNavigationAutoResult => {
         perspective: number,
         options?: FollowMyLocationOptions
       ) => {
-        const zoomLevel = options?.zoomLevel ?? -1;
-        NavAutoModule.setFollowingPerspective(perspective, zoomLevel);
+        NavAutoModule.setFollowingPerspective(perspective, options?.zoomLevel);
       },
 
       sendCustomMessage: (

--- a/src/auto/useNavigationAuto.ts
+++ b/src/auto/useNavigationAuto.ts
@@ -41,7 +41,10 @@ import type {
   GroundOverlayPositionOptions,
   MapColorScheme,
 } from '../maps';
-import type { NavigationNightMode } from '../navigation';
+import type {
+  FollowMyLocationOptions,
+  NavigationNightMode,
+} from '../navigation';
 import { useMemo, useCallback, useRef } from 'react';
 
 const { NavAutoModule } = NativeModules;
@@ -163,8 +166,12 @@ export const useNavigationAuto = (): UseNavigationAutoResult => {
         return await NavAutoModule.isAutoScreenAvailable();
       },
 
-      setFollowingPerspective: (perspective: number) => {
-        NavAutoModule.setFollowingPerspective(perspective);
+      setFollowingPerspective: (
+        perspective: number,
+        options?: FollowMyLocationOptions
+      ) => {
+        const zoomLevel = options?.zoomLevel ?? -1;
+        NavAutoModule.setFollowingPerspective(perspective, zoomLevel);
       },
 
       sendCustomMessage: (

--- a/src/maps/mapView/mapView.tsx
+++ b/src/maps/mapView/mapView.tsx
@@ -82,6 +82,19 @@ export const MapView = (props: MapViewProps): React.JSX.Element => {
     props.onMarkerInfoWindowTapped
   );
 
+  const { minZoomLevel, maxZoomLevel } = props;
+
+  const hasConflictingZoomLevels =
+    minZoomLevel != null && maxZoomLevel != null && minZoomLevel > maxZoomLevel;
+
+  useEffect(() => {
+    if (hasConflictingZoomLevels) {
+      console.warn(
+        `minZoomLevel (${minZoomLevel}) must not be greater than maxZoomLevel (${maxZoomLevel}). Zoom level constraints will be ignored.`
+      );
+    }
+  }, [hasConflictingZoomLevels, minZoomLevel, maxZoomLevel]);
+
   return (
     <NavView
       style={props.style ?? styles.defaultStyle}
@@ -108,8 +121,8 @@ export const MapView = (props: MapViewProps): React.JSX.Element => {
       zoomControlsEnabled={props.zoomControlsEnabled}
       zoomGesturesEnabled={props.zoomGesturesEnabled}
       buildingsEnabled={props.buildingsEnabled}
-      minZoomLevel={props.minZoomLevel}
-      maxZoomLevel={props.maxZoomLevel}
+      minZoomLevel={hasConflictingZoomLevels ? undefined : minZoomLevel}
+      maxZoomLevel={hasConflictingZoomLevels ? undefined : maxZoomLevel}
       onMapClick={onMapClick}
       onMapReady={onMapReady}
       onMarkerClick={onMarkerClick}

--- a/src/native/NativeNavAutoModule.ts
+++ b/src/native/NativeNavAutoModule.ts
@@ -150,7 +150,7 @@ export interface Spec extends TurboModule {
   setMyLocationButtonEnabled(enabled: boolean): void;
   setMapColorScheme(colorScheme: Int32): void;
   setNightMode(nightMode: Int32): void;
-  setFollowingPerspective(perspective: Int32): void;
+  setFollowingPerspective(perspective: Int32, zoomLevel: Double): void;
   setBuildingsEnabled(enabled: boolean): void;
   setZoomLevel(zoomLevel: Double): Promise<void>;
   setMapPadding(top: Double, left: Double, bottom: Double, right: Double): void;

--- a/src/native/NativeNavAutoModule.ts
+++ b/src/native/NativeNavAutoModule.ts
@@ -150,7 +150,10 @@ export interface Spec extends TurboModule {
   setMyLocationButtonEnabled(enabled: boolean): void;
   setMapColorScheme(colorScheme: Int32): void;
   setNightMode(nightMode: Int32): void;
-  setFollowingPerspective(perspective: Int32, zoomLevel: Double): void;
+  setFollowingPerspective(
+    perspective: Int32,
+    zoomLevel?: WithDefault<Float, null>
+  ): void;
   setBuildingsEnabled(enabled: boolean): void;
   setZoomLevel(zoomLevel: Double): Promise<void>;
   setMapPadding(top: Double, left: Double, bottom: Double, right: Double): void;

--- a/src/native/NativeNavViewModule.ts
+++ b/src/native/NativeNavViewModule.ts
@@ -142,7 +142,7 @@ export interface Spec extends TurboModule {
   setFollowingPerspective(
     nativeID: string,
     perspective: Int32,
-    zoomLevel: Double
+    zoomLevel?: WithDefault<Float, null>
   ): Promise<void>;
   moveCamera(
     nativeID: string,

--- a/src/native/NativeNavViewModule.ts
+++ b/src/native/NativeNavViewModule.ts
@@ -139,7 +139,11 @@ export interface Spec extends TurboModule {
     nativeID: string,
     options: GroundOverlayOptionsSpec
   ): Promise<GroundOverlay>;
-  setFollowingPerspective(nativeID: string, perspective: Int32): Promise<void>;
+  setFollowingPerspective(
+    nativeID: string,
+    perspective: Int32,
+    zoomLevel: Double
+  ): Promise<void>;
   moveCamera(
     nativeID: string,
     cameraPosition: CameraPositionSpec

--- a/src/navigation/navigationView/navigationView.tsx
+++ b/src/navigation/navigationView/navigationView.tsx
@@ -221,6 +221,19 @@ export const NavigationView = (
     [onPromptVisibilityChangedProp]
   );
 
+  const { minZoomLevel, maxZoomLevel } = props;
+
+  const hasConflictingZoomLevels =
+    minZoomLevel != null && maxZoomLevel != null && minZoomLevel > maxZoomLevel;
+
+  useEffect(() => {
+    if (hasConflictingZoomLevels) {
+      console.warn(
+        `minZoomLevel (${minZoomLevel}) must not be greater than maxZoomLevel (${maxZoomLevel}). Zoom level constraints will be ignored.`
+      );
+    }
+  }, [hasConflictingZoomLevels, minZoomLevel, maxZoomLevel]);
+
   return (
     <NavView
       style={props.style ?? styles.defaultStyle}
@@ -264,8 +277,8 @@ export const NavigationView = (
       zoomGesturesEnabled={props.zoomGesturesEnabled}
       buildingsEnabled={props.buildingsEnabled}
       reportIncidentButtonEnabled={props.reportIncidentButtonEnabled}
-      minZoomLevel={props.minZoomLevel}
-      maxZoomLevel={props.maxZoomLevel}
+      minZoomLevel={hasConflictingZoomLevels ? undefined : minZoomLevel}
+      maxZoomLevel={hasConflictingZoomLevels ? undefined : maxZoomLevel}
       onMapClick={onMapClick}
       onMapReady={onMapReady}
       onMarkerClick={onMarkerClick}

--- a/src/navigation/navigationView/navigationViewController.ts
+++ b/src/navigation/navigationView/navigationViewController.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import type { CameraPerspective, NavigationViewController } from './types';
+import type {
+  CameraPerspective,
+  FollowMyLocationOptions,
+  NavigationViewController,
+} from './types';
 import NavViewModule from '../../native/NativeNavViewModule';
 
 /**
@@ -41,9 +45,17 @@ export const getNavigationViewController = (
         console.error('Error calling setNavigationUIEnabled:', error);
       }
     },
-    setFollowingPerspective: async (perspective: CameraPerspective) => {
+    setFollowingPerspective: async (
+      perspective: CameraPerspective,
+      options?: FollowMyLocationOptions
+    ) => {
       try {
-        await NavViewModule.setFollowingPerspective(nativeID, perspective);
+        const zoomLevel = options?.zoomLevel ?? -1;
+        await NavViewModule.setFollowingPerspective(
+          nativeID,
+          perspective,
+          zoomLevel
+        );
       } catch (error) {
         console.error('Error calling setFollowingPerspective:', error);
       }

--- a/src/navigation/navigationView/navigationViewController.ts
+++ b/src/navigation/navigationView/navigationViewController.ts
@@ -50,11 +50,10 @@ export const getNavigationViewController = (
       options?: FollowMyLocationOptions
     ) => {
       try {
-        const zoomLevel = options?.zoomLevel ?? -1;
         await NavViewModule.setFollowingPerspective(
           nativeID,
           perspective,
-          zoomLevel
+          options?.zoomLevel
         );
       } catch (error) {
         console.error('Error calling setFollowingPerspective:', error);

--- a/src/navigation/navigationView/types.ts
+++ b/src/navigation/navigationView/types.ts
@@ -165,6 +165,18 @@ export enum NavigationNightMode {
 }
 
 /**
+ * Options for controlling camera behavior when following the user's location.
+ */
+export interface FollowMyLocationOptions {
+  /**
+   * A fixed zoom level to use when the camera is following the user's location.
+   * When set, the Navigation SDK's auto-zoom is overridden with this value.
+   * Omit or set to undefined to use the default Nav SDK auto-zoom.
+   */
+  zoomLevel?: number;
+}
+
+/**
  * Allows you to access Navigator methods.
  */
 export interface NavigationViewController {
@@ -180,7 +192,12 @@ export interface NavigationViewController {
   setNavigationUIEnabled(enabled: boolean): Promise<void>;
 
   /**
-   * Sets the camera perspective for navigation.
+   * Sets the camera perspective for navigation and enables camera following mode.
+   * @param perspective - The camera perspective to use.
+   * @param options - Optional settings for camera follow behavior (e.g., fixed zoom level).
    */
-  setFollowingPerspective(perspective: CameraPerspective): Promise<void>;
+  setFollowingPerspective(
+    perspective: CameraPerspective,
+    options?: FollowMyLocationOptions
+  ): Promise<void>;
 }


### PR DESCRIPTION
Android Fabric delivers minZoomLevel and maxZoomLevel prop updates in
arbitrary order, which could create a transient state where min > max,
crashing the app with IllegalArgumentException. Fix by resetting both
zoom preferences before atomically re-applying the pair.

Add zoomLevel parameter to setFollowingPerspective so zoom can be
controlled during active navigation. On Android this uses
FollowMyLocationOptions; on iOS it sets followingZoomLevel on the map
view (or GMSNavigationNoFollowingZoomLevel to reset).

Fixes #570
Fixes #550

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/