### PR TITLE
fix: load marker images from path, not from the assets

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
@@ -263,7 +263,7 @@ public class MapViewController implements INavigationViewControllerProperties {
     MarkerOptions options = new MarkerOptions();
     if (imagePath != null && !imagePath.isEmpty()) {
       try {
-        BitmapDescriptor icon = BitmapDescriptorFactory.fromAsset(imagePath);
+        BitmapDescriptor icon = BitmapDescriptorFactory.fromPath(imagePath);
         options.icon(icon);
       } catch (Exception e) {
         throw new IllegalArgumentException(JsErrors.INVALID_IMAGE_ERROR_MESSAGE);

--- a/ios/react-native-navigation-sdk/NavAutoModule.mm
+++ b/ios/react-native-navigation-sdk/NavAutoModule.mm
@@ -145,7 +145,7 @@ static NavAutoModuleReadyCallback _navAutoModuleReadyCallback;
       NSString *imgPath = optionsCopy.imgPath();
       UIImage *icon = nil;
       if (imgPath && [imgPath isKindOfClass:[NSString class]] && imgPath.length > 0) {
-        icon = [UIImage imageNamed:imgPath];
+        icon = [UIImage imageWithContentsOfFile:imgPath];
         if (!icon) {
           reject(@"INVALID_IMAGE", @"Failed to load image from the provided path", nil);
           return;
@@ -321,7 +321,7 @@ static NavAutoModuleReadyCallback _navAutoModuleReadyCallback;
     dispatch_async(dispatch_get_main_queue(), ^{
       NSString *imgPath = optionsCopy.imgPath();
       UIImage *icon = (imgPath && [imgPath isKindOfClass:[NSString class]])
-                          ? [UIImage imageNamed:imgPath]
+                          ? [UIImage imageWithContentsOfFile:imgPath]
                           : nil;
 
       if (!icon) {

--- a/ios/react-native-navigation-sdk/NavViewModule.mm
+++ b/ios/react-native-navigation-sdk/NavViewModule.mm
@@ -148,7 +148,7 @@ static NavViewModule *sharedInstance = nil;
       NSString *imgPath = optionsCopy.imgPath();
       UIImage *icon = nil;
       if (imgPath && [imgPath isKindOfClass:[NSString class]] && imgPath.length > 0) {
-        icon = [UIImage imageNamed:imgPath];
+        icon = [UIImage imageWithContentsOfFile:imgPath];
         if (!icon) {
           reject(@"INVALID_IMAGE", @"Failed to load image from the provided path", nil);
           return;
@@ -288,7 +288,7 @@ static NavViewModule *sharedInstance = nil;
     dispatch_async(dispatch_get_main_queue(), ^{
       NSString *imgPath = optionsCopy.imgPath();
       UIImage *icon = (imgPath && [imgPath isKindOfClass:[NSString class]])
-                          ? [UIImage imageNamed:imgPath]
+                          ? [UIImage imageWithContentsOfFile:imgPath]
                           : nil;
 
       if (!icon) {


### PR DESCRIPTION
## Summary
This PR fixes how marker pin images passed from React Native are loaded in MapView.

## Motivation
The current implementation uses a method for loading files from the app's asset directory, which is not appropriate for loading images from the React Native JavaScript runtime.  

## Test
Tests are not added since it's a small bug fix, but I confirmed it works.
<img width="493" height="502.5" alt="image" src="https://github.com/user-attachments/assets/d583dab5-7b26-41cd-9f92-8ce101d70df6" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/