### PR TITLE
feat: add `MapController.animateCamera()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ The `MapViewController` is provided via the `onMapViewControllerCreated` callbac
 | `removeCircle(id: string)`                        | `void`                    | Remove a circle by its ID                                                                  |
 | `removeGroundOverlay(id: string)`                 | `void`                    | Remove a ground overlay by its ID                                                          |
 | `moveCamera(position: CameraPosition)`            | `void`                    | Move camera to a new position                                                              |
+| `animateCamera(position: CameraPosition, duration?: number \| null)` | `Promise<void>`           | Animate camera to a new position. Defaults to 500 ms when duration is omitted              |
 | `setZoomLevel(level: number)`                     | `void`                    | Set the map zoom level                                                                     |
 | `setPadding(padding: Padding)`                    | `void`                    | Set padding on the map                                                                     |
 | `getCameraPosition()`                             | `Promise<CameraPosition>` | Get the current camera position                                                            |

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
@@ -787,7 +787,15 @@ public class MapViewController implements INavigationViewControllerProperties {
       return;
     }
 
-    LatLng latLng = ObjectTranslationUtil.getLatLngFromMap((Map<String, Object>) map.get("target"));
+    Object targetObj = map.get("target");
+    if (targetObj == null) {
+      return;
+    }
+
+    LatLng latLng = ObjectTranslationUtil.getLatLngFromMap((Map<String, Object>) targetObj);
+    if (latLng == null) {
+      return;
+    }
 
     float zoom = (float) CollectionUtil.getDouble("zoom", map, 0);
     float tilt = (float) CollectionUtil.getDouble("tilt", map, 0);

--- a/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
+++ b/android/src/main/java/com/google/android/react/navsdk/MapViewController.java
@@ -808,24 +808,38 @@ public class MapViewController implements INavigationViewControllerProperties {
   }
 
   public void animateCamera(Map<String, Object> map) {
-    if (mGoogleMap != null) {
-      int zoom = CollectionUtil.getInt("zoom", map, 0);
-      int tilt = CollectionUtil.getInt("tilt", map, 0);
-      int bearing = CollectionUtil.getInt("bearing", map, 0);
-      int animationDuration = CollectionUtil.getInt("duration", map, 0);
+    if (mGoogleMap == null) {
+      return;
+    }
 
-      CameraPosition cameraPosition =
-          new CameraPosition.Builder()
-              .target(
-                  ObjectTranslationUtil.getLatLngFromMap(
-                      (Map<String, Object>) map.get("target"))) // Set the target location
-              .zoom(zoom) // Set the desired zoom level
-              .tilt(tilt) // Set the desired tilt angle (0 for straight down, 90 for straight up)
-              .bearing(bearing) // Set the desired bearing (rotation angle in degrees)
-              .build();
+    Object targetObj = map.get("target");
+    if (targetObj == null) {
+      return;
+    }
 
+    LatLng latLng = ObjectTranslationUtil.getLatLngFromMap((Map<String, Object>) targetObj);
+    if (latLng == null) {
+      return;
+    }
+
+    int zoom = CollectionUtil.getInt("zoom", map, 0);
+    int tilt = CollectionUtil.getInt("tilt", map, 0);
+    int bearing = CollectionUtil.getInt("bearing", map, 0);
+    int animationDuration = CollectionUtil.getInt("duration", map, 0);
+
+    CameraPosition cameraPosition =
+        new CameraPosition.Builder()
+            .target(latLng)
+            .zoom(zoom) // Set the desired zoom level
+            .tilt(tilt) // Set the desired tilt angle (0 for straight down, 90 for straight up)
+            .bearing(bearing) // Set the desired bearing (rotation angle in degrees)
+            .build();
+
+    if (animationDuration > 0) {
       mGoogleMap.animateCamera(
           CameraUpdateFactory.newCameraPosition(cameraPosition), animationDuration, null);
+    } else {
+      mGoogleMap.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
     }
   }
 

--- a/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
@@ -613,6 +613,25 @@ public class NavAutoModule extends NativeNavAutoModuleSpec
   }
 
   @Override
+  public void animateCamera(
+      ReadableMap cameraPosition, @Nullable Double duration, final Promise promise) {
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          if (mMapViewController == null) {
+            promise.reject(JsErrors.NO_MAP_ERROR_CODE, JsErrors.NO_MAP_ERROR_MESSAGE);
+            return;
+          }
+
+          Map<String, Object> map = cameraPosition.toHashMap();
+          if (duration != null) {
+            map.put("duration", duration.doubleValue());
+          }
+          mMapViewController.animateCamera(map);
+          promise.resolve(null);
+        });
+  }
+
+  @Override
   public void isAutoScreenAvailable(final Promise promise) {
     promise.resolve(mMapViewController != null);
   }

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewModule.java
@@ -14,6 +14,7 @@
 package com.google.android.react.navsdk;
 
 import android.location.Location;
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -257,6 +258,29 @@ public class NavViewModule extends NativeNavViewModuleSpec {
           }
 
           fragment.getMapController().moveCamera(cameraPosition.toHashMap());
+          promise.resolve(null);
+        });
+  }
+
+  @Override
+  public void animateCamera(
+      String nativeID,
+      ReadableMap cameraPosition,
+      @Nullable Double duration,
+      final Promise promise) {
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          IMapViewFragment fragment = mNavViewManager.getFragmentByNativeId(nativeID);
+          if (fragment == null) {
+            promise.reject(JsErrors.NO_MAP_ERROR_CODE, JsErrors.NO_MAP_ERROR_MESSAGE);
+            return;
+          }
+
+          Map<String, Object> map = cameraPosition.toHashMap();
+          if (duration != null) {
+            map.put("duration", duration.doubleValue());
+          }
+          fragment.getMapController().animateCamera(map);
           promise.resolve(null);
         });
   }

--- a/example/e2e/map.test.js
+++ b/example/e2e/map.test.js
@@ -41,56 +41,63 @@ describe('Map view tests', () => {
     await expectSuccess();
   });
 
-  it('MT03 - initialize map and test camera tilt bearing zoom', async () => {
+  it('MT03 - initialize map and test animate camera', async () => {
+    await selectTestByName('testAnimateCamera');
+    await waitForTestToFinish();
+    await expectNoErrors();
+    await expectSuccess();
+  });
+
+  it('MT04 - initialize map and test camera tilt bearing zoom', async () => {
     await selectTestByName('testTiltZoomBearingCamera');
     await waitForTestToFinish();
     await expectNoErrors();
     await expectSuccess();
   });
 
-  it('MT04 - test adding and removing markers', async () => {
+  it('MT05 - test adding and removing markers', async () => {
     await selectTestByName('testMapMarkers');
     await waitForTestToFinish();
     await expectNoErrors();
     await expectSuccess();
   });
 
-  it('MT05 - test adding and removing circles', async () => {
+  it('MT06 - test adding and removing circles', async () => {
     await selectTestByName('testMapCircles');
     await waitForTestToFinish();
     await expectNoErrors();
     await expectSuccess();
   });
 
-  it('MT06 - test adding and removing polylines', async () => {
+  it('MT07 - test adding and removing polylines', async () => {
     await selectTestByName('testMapPolylines');
     await waitForTestToFinish();
     await expectNoErrors();
     await expectSuccess();
   });
 
-  it('MT07 - test adding and removing polygons', async () => {
+  it('MT08 - test adding and removing polygons', async () => {
     await selectTestByName('testMapPolygons');
     await waitForTestToFinish();
     await expectNoErrors();
     await expectSuccess();
   });
 
-  it('MT08 - test adding and removing ground overlays', async () => {
+  it('MT09 - test adding and removing ground overlays', async () => {
     await selectTestByName('testMapGroundOverlays');
     await waitForTestToFinish();
     await expectNoErrors();
     await expectSuccess();
   });
 
-  it('MT09 - test setting map style via JSON', async () => {
+  it('MT10 - test setting map style via JSON', async () => {
     await selectTestByName('testMapStyle');
     await waitForTestToFinish();
     await expectNoErrors();
     await expectSuccess();
   });
 
-  it('MT10 - test min and max zoom level constraints', async () => {
+  it('MT11 - test min and max zoom level constraints', async () => {
     await selectTestByName('testMinMaxZoomLevels');
     await waitForTestToFinish();
     await expectNoErrors();

--- a/example/src/controls/mapsControls.tsx
+++ b/example/src/controls/mapsControls.tsx
@@ -142,6 +142,15 @@ const MapsControls: React.FC<MapControlsProps> = ({
     });
   };
 
+  const animateCamera = () => {
+    mapViewController.animateCamera({
+      target: { lat: Number(latitude), lng: Number(longitude) },
+      zoom: 1,
+      bearing: 60,
+      tilt: 60,
+    });
+  };
+
   const setMapType = (newMapType: MapType) => {
     onMapTypeChange?.(newMapType);
   };
@@ -410,6 +419,7 @@ const MapsControls: React.FC<MapControlsProps> = ({
           keyboardType="numeric"
         />
         <ExampleAppButton title="Move camera" onPress={moveCamera} />
+        <ExampleAppButton title="Animate camera" onPress={animateCamera} />
         <ExampleAppButton
           title="Zoom in"
           onPress={() => {

--- a/example/src/screens/IntegrationTestsScreen.tsx
+++ b/example/src/screens/IntegrationTestsScreen.tsx
@@ -42,6 +42,7 @@ import {
   testRouteSegments,
   testGetCurrentTimeAndDistance,
   testMoveCamera,
+  testAnimateCamera,
   testTiltZoomBearingCamera,
   testMapMarkers,
   testMapCircles,
@@ -279,6 +280,9 @@ const IntegrationTestsScreen = () => {
       case 'testMoveCamera':
         await testMoveCamera(getTestTools());
         break;
+      case 'testAnimateCamera':
+        await testAnimateCamera(getTestTools());
+        break;
       case 'testTiltZoomBearingCamera':
         await testTiltZoomBearingCamera(getTestTools());
         break;
@@ -450,6 +454,13 @@ const IntegrationTestsScreen = () => {
             runTest('testMoveCamera');
           }}
           testID="testMoveCamera"
+        />
+        <ExampleAppButton
+          title="testAnimateCamera"
+          onPress={() => {
+            runTest('testAnimateCamera');
+          }}
+          testID="testAnimateCamera"
         />
         <ExampleAppButton
           title="testTiltZoomBearingCamera"

--- a/example/src/screens/integration_tests/integration_test.ts
+++ b/example/src/screens/integration_tests/integration_test.ts
@@ -814,6 +814,55 @@ export const testMoveCamera = async (testTools: TestTools) => {
   passTest();
 };
 
+export const testAnimateCamera = async (testTools: TestTools) => {
+  const { mapViewController, passTest, failTest, expectFalseError } = testTools;
+  if (!mapViewController) {
+    return failTest('mapViewController was expected to exist');
+  }
+
+  // Animate camera to Hong Kong
+  await mapViewController.animateCamera({
+    target: {
+      lat: 22.2987849,
+      lng: 114.1719271,
+    },
+  });
+
+  const hongKongPosition = await waitForCondition(
+    () => mapViewController.getCameraPosition(),
+    position =>
+      roundDown(position.target.lat) === 22 &&
+      roundDown(position.target.lng) === 114
+  );
+  if (!hongKongPosition) {
+    expectFalseError(
+      'roundDown(hongKongPosition.target.lat) !== 22 || roundDown(hongKongPosition.target.lng) !== 114'
+    );
+  }
+
+  // Animate camera to Tokyo
+  await mapViewController.animateCamera({
+    target: {
+      lat: 35.6805707,
+      lng: 139.7658596,
+    },
+  });
+
+  const tokyoPosition = await waitForCondition(
+    () => mapViewController.getCameraPosition(),
+    position =>
+      roundDown(position.target.lat) === 35 &&
+      roundDown(position.target.lng) === 139
+  );
+  if (!tokyoPosition) {
+    expectFalseError(
+      'roundDown(tokyoPosition.target.lat) !== 35 || roundDown(tokyoPosition.target.lng) !== 139'
+    );
+  }
+
+  passTest();
+};
+
 export const testTiltZoomBearingCamera = async (testTools: TestTools) => {
   const { mapViewController, passTest, failTest, expectFalseError } = testTools;
   if (!mapViewController) {

--- a/ios/react-native-navigation-sdk/NavAutoModule.mm
+++ b/ios/react-native-navigation-sdk/NavAutoModule.mm
@@ -432,6 +432,43 @@ static NavAutoModuleReadyCallback _navAutoModuleReadyCallback;
   }
 }
 
+- (void)animateCamera:(CameraPositionSpec &)cameraPosition
+             duration:(double)duration
+              resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject {
+  CameraPositionSpec positionCopy(cameraPosition);
+  if (_viewController) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      GMSMutableCameraPosition *position = [[GMSMutableCameraPosition alloc] init];
+
+      if (positionCopy.target().has_value()) {
+        auto target = positionCopy.target().value();
+        position.target = CLLocationCoordinate2DMake(target.lat(), target.lng());
+      }
+
+      if (positionCopy.zoom().has_value()) {
+        position.zoom = positionCopy.zoom().value();
+      }
+
+      if (positionCopy.bearing().has_value()) {
+        position.bearing = positionCopy.bearing().value();
+      }
+
+      if (positionCopy.tilt().has_value()) {
+        position.viewingAngle = positionCopy.tilt().value();
+      }
+
+      [self->_viewController animateCameraToPosition:position
+                                            duration:duration
+                                              result:^(BOOL success) {
+                                                resolve(@(success));
+                                              }];
+    });
+  } else {
+    reject(@"NO_VIEW_CONTROLLER", @"No view controller found", nil);
+  }
+}
+
 - (void)removeMarker:(NSString *)id
              resolve:(RCTPromiseResolveBlock)resolve
               reject:(RCTPromiseRejectBlock)reject {

--- a/ios/react-native-navigation-sdk/NavViewController.h
+++ b/ios/react-native-navigation-sdk/NavViewController.h
@@ -72,6 +72,9 @@ typedef void (^OnArrayResult)(NSArray *_Nullable result);
 - (void)setRecenterButtonEnabled:(BOOL)isEnabled;
 - (void)resetMinMaxZoomLevel;
 - (void)animateCamera:(GMSCameraUpdate *)update;
+- (void)animateCameraToPosition:(GMSCameraPosition *)position
+                       duration:(double)duration
+                         result:(OnBooleanResult)completionBlock;
 - (void)setMapStyle:(GMSMapStyle *)mapStyle;
 - (void)setMapType:(GMSMapViewType)mapType;
 - (void)clearMapView;

--- a/ios/react-native-navigation-sdk/NavViewController.mm
+++ b/ios/react-native-navigation-sdk/NavViewController.mm
@@ -970,6 +970,12 @@
 }
 
 - (void)animateCamera:(GMSCameraUpdate *)update result:(OnBooleanResult)completionBlock {
+  if (_mapView == nil || update == nil) {
+    if (completionBlock) {
+      completionBlock(NO);
+    }
+    return;
+  }
   [_mapView animateWithCameraUpdate:update];
   if (completionBlock) {
     completionBlock(YES);

--- a/ios/react-native-navigation-sdk/NavViewController.mm
+++ b/ios/react-native-navigation-sdk/NavViewController.mm
@@ -16,6 +16,7 @@
 
 #import "NavViewController.h"
 #import <GoogleNavigation/GoogleNavigation.h>
+#import <QuartzCore/QuartzCore.h>
 #import <React/RCTLog.h>
 #import <UserNotifications/UserNotifications.h>
 #import "CustomTypes.h"
@@ -970,6 +971,30 @@
 
 - (void)animateCamera:(GMSCameraUpdate *)update result:(OnBooleanResult)completionBlock {
   [_mapView animateWithCameraUpdate:update];
+  if (completionBlock) {
+    completionBlock(YES);
+  }
+}
+
+- (void)animateCameraToPosition:(GMSCameraPosition *)position
+                       duration:(double)duration
+                         result:(OnBooleanResult)completionBlock {
+  if (_mapView == nil || position == nil) {
+    if (completionBlock) {
+      completionBlock(NO);
+    }
+    return;
+  }
+
+  if (duration > 0) {
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:duration / 1000.0];
+    [_mapView animateToCameraPosition:position];
+    [CATransaction commit];
+  } else {
+    [_mapView animateToCameraPosition:position];
+  }
+
   if (completionBlock) {
     completionBlock(YES);
   }

--- a/ios/react-native-navigation-sdk/NavViewModule.mm
+++ b/ios/react-native-navigation-sdk/NavViewModule.mm
@@ -400,6 +400,47 @@ static NavViewModule *sharedInstance = nil;
   }
 }
 
+- (void)animateCamera:(NSString *)nativeID
+       cameraPosition:(CameraPositionSpec &)cameraPosition
+             duration:(double)duration
+              resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject {
+  NavViewController *viewController = [self getViewControllerForNativeID:nativeID];
+  CameraPositionSpec positionCopy(cameraPosition);
+  if (viewController) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      GMSMutableCameraPosition *position = [[GMSMutableCameraPosition alloc] init];
+
+      if (positionCopy.target().has_value()) {
+        auto target = positionCopy.target().value();
+        position.target = CLLocationCoordinate2DMake(target.lat(), target.lng());
+      }
+
+      if (positionCopy.zoom().has_value()) {
+        position.zoom = positionCopy.zoom().value();
+      }
+
+      if (positionCopy.bearing().has_value()) {
+        position.bearing = positionCopy.bearing().value();
+      }
+
+      if (positionCopy.tilt().has_value()) {
+        position.viewingAngle = positionCopy.tilt().value();
+      }
+
+      [viewController animateCameraToPosition:position
+                                     duration:duration
+                                       result:^(BOOL success) {
+                                         if (resolve) {
+                                           resolve(@(success));
+                                         }
+                                       }];
+    });
+  } else {
+    reject(@"NO_VIEW_CONTROLLER", @"No view controller found for the specified nativeID", nil);
+  }
+}
+
 - (void)getCameraPosition:(NSString *)nativeID
                   resolve:(RCTPromiseResolveBlock)resolve
                    reject:(RCTPromiseRejectBlock)reject {

--- a/src/auto/useNavigationAuto.ts
+++ b/src/auto/useNavigationAuto.ts
@@ -370,6 +370,20 @@ export const useNavigationAuto = (): UseNavigationAutoResult => {
         return NavAutoModule.moveCamera(cameraPosition);
       },
 
+      // set default values to transition similar to Google Maps app
+      animateCamera: (
+        cameraPosition: CameraPosition,
+        duration?: number | null
+      ) => {
+        return NavAutoModule.animateCamera(
+          {
+            ...cameraPosition,
+            zoom: cameraPosition.zoom ?? 15,
+          },
+          duration === undefined ? 500 : duration
+        );
+      },
+
       setPadding: (padding: Padding) => {
         const { top = 0, left = 0, bottom = 0, right = 0 } = padding;
         return NavAutoModule.setMapPadding(top, left, bottom, right);

--- a/src/maps/mapView/mapView.tsx
+++ b/src/maps/mapView/mapView.tsx
@@ -52,7 +52,7 @@ export const MapView = (props: MapViewProps): React.JSX.Element => {
           target: props.initialCameraPosition?.target ?? null,
           bearing: props.initialCameraPosition?.bearing ?? 0.0,
           tilt: props.initialCameraPosition?.tilt ?? 0.0,
-          zoom: props.initialCameraPosition?.zoom ?? 0.0,
+          zoom: props.initialCameraPosition?.zoom ?? 15,
         },
       }),
     };

--- a/src/maps/mapView/mapViewController.ts
+++ b/src/maps/mapView/mapViewController.ts
@@ -16,7 +16,7 @@
 
 import NavViewModule from '../../native/NativeNavViewModule';
 import { processColorValue, colorIntToRGBA } from '../../shared';
-import type { Location } from '../../shared/types';
+import type { Location } from '../../shared';
 import type {
   CameraPosition,
   Circle,
@@ -193,6 +193,21 @@ export const getMapViewController = (nativeID: string): MapViewController => {
 
     moveCamera: async (cameraPosition: CameraPosition) => {
       return await NavViewModule.moveCamera(nativeID, cameraPosition);
+    },
+
+    animateCamera: async (
+      cameraPosition: CameraPosition,
+      duration?: number | null
+    ) => {
+      // set default values to transition similar to Google Maps app
+      return await NavViewModule.animateCamera(
+        nativeID,
+        {
+          ...cameraPosition,
+          zoom: cameraPosition.zoom ?? 15,
+        },
+        duration === undefined ? 500 : duration
+      );
     },
 
     setPadding: async _padding => {

--- a/src/maps/mapView/types.ts
+++ b/src/maps/mapView/types.ts
@@ -376,7 +376,19 @@ export interface MapViewController {
    *
    * @param cameraPosition - Defines the position the camera will take with the move.
    */
-  moveCamera(cameraPosition: CameraPosition): void;
+  moveCamera(cameraPosition: CameraPosition): Promise<void>;
+
+  /**
+   * Animate the camera to a new position based on the object given.
+   *
+   * @param cameraPosition - Defines the position the camera will animate to.
+   * @param duration - Animation duration in milliseconds. Defaults to 500 ms when undefined.
+   * Pass null to use the native SDK's default animation duration.
+   */
+  animateCamera(
+    cameraPosition: CameraPosition,
+    duration?: number | null
+  ): Promise<void>;
 
   /**
    * Sets padding to the map.

--- a/src/native/NativeNavAutoModule.ts
+++ b/src/native/NativeNavAutoModule.ts
@@ -138,6 +138,10 @@ export interface Spec extends TurboModule {
   addPolygon(options: PolygonOptionsSpec): Promise<Polygon>;
   addGroundOverlay(options: GroundOverlayOptionsSpec): Promise<GroundOverlay>;
   moveCamera(cameraPosition: CameraPositionSpec): Promise<void>;
+  animateCamera(
+    cameraPosition: CameraPositionSpec,
+    duration?: WithDefault<Double, null>
+  ): Promise<void>;
   removeMarker(id: string): Promise<boolean>;
   removePolyline(id: string): Promise<boolean>;
   removePolygon(id: string): Promise<boolean>;

--- a/src/native/NativeNavViewModule.ts
+++ b/src/native/NativeNavViewModule.ts
@@ -148,6 +148,11 @@ export interface Spec extends TurboModule {
     nativeID: string,
     cameraPosition: CameraPositionSpec
   ): Promise<void>;
+  animateCamera(
+    nativeID: string,
+    cameraPosition: CameraPositionSpec,
+    duration?: WithDefault<Double, null>
+  ): Promise<void>;
   getCameraPosition(nativeID: string): Promise<CameraPosition>;
   getMyLocation(nativeID: string): Promise<Location>;
   getUiSettings(nativeID: string): Promise<UISettings>;


### PR DESCRIPTION
Adds an `animateCamera` API for map views and Android Auto, backed by native implementations on both Android and iOS.

The new API accepts a `CameraPosition` and an optional animation duration. TypeScript wrappers default zoom to `15` and duration to `500` ms, while `duration=null` lets the native SDK default duration apply. 

Native modules now expose `animateCamera` through both `NavViewModule` and `NavAutoModule`; Android uses `GoogleMap.animateCamera`, and iOS animates to a `GMSCameraPosition` with `CATransaction` when a duration is supplied.

This also adds example controls, plus an integration/e2e test path that animates between Hong Kong and Tokyo and verifies the final camera target.

## Issues
- #584 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/