### PR TITLE
fix!: change the fabric codegen defaults to match the native SDKs

### DIFF
--- a/ios/react-native-navigation-sdk/NavView.mm
+++ b/ios/react-native-navigation-sdk/NavView.mm
@@ -28,8 +28,13 @@
 
 using namespace facebook::react;
 
-static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps =
-    std::make_shared<const NavViewProps>();
+static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps = [] {
+  auto props = std::make_shared<NavViewProps>();
+  // On iOS, Google Maps Navigation SDK has the compass disabled by default.
+  // The Fabric default is overridden here so initial props match the native SDK behavior.
+  props->compassEnabled = false;
+  return std::static_pointer_cast<const NavViewProps>(props);
+}();
 
 @interface NavView () <RCTNavViewViewProtocol>
 

--- a/src/native/NativeNavViewComponent.ts
+++ b/src/native/NativeNavViewComponent.ts
@@ -119,8 +119,8 @@ export interface NativeNavViewProps extends ViewProps {
   trafficIncidentCardsEnabled?: WithDefault<boolean, true>;
   headerEnabled?: WithDefault<boolean, true>;
   footerEnabled?: WithDefault<boolean, true>;
-  speedometerEnabled?: WithDefault<boolean, true>;
-  speedLimitIconEnabled?: WithDefault<boolean, true>;
+  speedometerEnabled?: WithDefault<boolean, false>;
+  speedLimitIconEnabled?: WithDefault<boolean, false>;
   recenterButtonEnabled?: WithDefault<boolean, true>;
   reportIncidentButtonEnabled?: WithDefault<boolean, true>;
   navigationViewStylingOptions?: UnsafeMixed;


### PR DESCRIPTION
Change the navigation view fabric defaults to match the native SDK behavior.

BREAKING CHANGE: `speedLimitIconEnabled` and `speedometerEnabled` prop value now defaults to false to match the platform SDK implementations.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/