### PR TITLE
feat: upgrade Android SDK to 7.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,6 +59,6 @@ dependencies {
   implementation "androidx.car.app:app:1.4.0"
   implementation "androidx.car.app:app-projected:1.4.0"
   implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-  implementation "com.google.android.libraries.navigation:navigation:7.6.0"
+  implementation "com.google.android.libraries.navigation:navigation:7.6.1"
   api 'com.google.guava:guava:31.0.1-android'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -153,7 +153,7 @@ dependencies {
     implementation "androidx.car.app:app-projected:1.4.0"
 
     // Include the Google Navigation SDK.
-    implementation 'com.google.android.libraries.navigation:navigation:7.6.0'
+    implementation 'com.google.android.libraries.navigation:navigation:7.6.1'
 }
 
 secrets {


### PR DESCRIPTION
Upgrades Android SDK to 7.6.1
See release notes at: https://developers.google.com/maps/documentation/navigation/android-sdk/release-notes#May_13_2026

Closes #599 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/