### PR TITLE
feat: upgrade iOS SDK to 10.13.0

### DIFF
--- a/react-native-navigation-sdk.podspec
+++ b/react-native-navigation-sdk.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.public_header_files = "ios/**/*.h"
 
   s.dependency "React-Core"
-  s.dependency "GoogleNavigation", "10.12.0"
+  s.dependency "GoogleNavigation", "10.13.0"
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
Upgrades iOS SDK to 10.13.0
See release notes at: https://developers.google.com/maps/documentation/navigation/ios-sdk/release-notes#April_30_2026

Closes #600 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/