### PR TITLE
chore: update ci versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
 
   build-ios:
     runs-on:
-      labels: macos-latest-xlarge
+      labels: macos-26-xlarge
     timeout-minutes: 45
     env:
       TURBO_CACHE_DIR: .turbo/ios
@@ -203,8 +203,8 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       
-      - name: Select XCode 26.3
-        run: sudo xcode-select -s '/Applications/Xcode_26.3.0.app/Contents/Developer'
+      - name: Select XCode 26.5
+        run: sudo xcode-select -s '/Applications/Xcode_26.5.0.app/Contents/Developer'
 
       - name: Cache turborepo for iOS
         uses: actions/cache@v3

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -61,7 +61,7 @@ module.exports = {
       type: 'ios.simulator',
       device: {
         type: 'iPhone 17 Pro',
-        os: 'iOS 26.4',
+        os: 'iOS 26.5',
       },
     },
     attached: {


### PR DESCRIPTION
- Pin CI macos to 26
- Update CI Xcode and iOS to 26.5

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/