### PR TITLE
docs: add ios background modes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ To set up, specify your API key in the application delegate `ios/Runner/AppDeleg
 
 ```
 
+#### Add the correct background modes to Info.plist file
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>location</string>
+    <string>audio</string>
+</array>
+```
+
 ## Usage
 
 ### Initializing Navigation


### PR DESCRIPTION
Add missing iOS background modes documentation

Fixes: https://github.com/googlemaps/react-native-navigation-sdk/issues/400

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/