### PR TITLE
fix: enable android turn by turn events on background

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -351,6 +351,7 @@ public class NavModule extends NativeNavModuleSpec
       }
       pendingInitPromise.reject(errorCodeStr, errorMessage);
       pendingInitPromise = null;
+      UiThreadUtil.runOnUiThread(this::removeNavInfoObserver);
     }
   }
 

--- a/android/src/main/java/com/google/android/react/navsdk/NavModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavModule.java
@@ -17,7 +17,6 @@ import android.app.Activity;
 import android.location.Location;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.Observer;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -286,17 +285,15 @@ public class NavModule extends NativeNavModuleSpec
     // Initialize the navigation API
     initializeNavigationApi();
 
-    // Observe live data for nav info updates.
+    // Observe nav info independently from the current Activity lifecycle.
+    // Background turn-by-turn updates continue to arrive in NavInfoReceivingService even when the
+    // app is paused, so using an Activity-bound LiveData observer drops them while backgrounded.
     // Remove any existing observer first to prevent duplicates after cleanup+reinit cycles.
     UiThreadUtil.runOnUiThread(
         () -> {
           removeNavInfoObserver();
           mNavInfoObserver = this::showNavInfo;
-          final Activity currentActivity = getReactApplicationContext().getCurrentActivity();
-          if (currentActivity != null) {
-            NavInfoReceivingService.getNavInfoLiveData()
-                .observe((LifecycleOwner) currentActivity, mNavInfoObserver);
-          }
+          NavInfoReceivingService.getNavInfoLiveData().observeForever(mNavInfoObserver);
         });
   }
 
@@ -1093,5 +1090,7 @@ public class NavModule extends NativeNavModuleSpec
   public void onHostPause() {}
 
   @Override
-  public void onHostDestroy() {}
+  public void onHostDestroy() {
+    UiThreadUtil.runOnUiThread(this::removeNavInfoObserver);
+  }
 }


### PR DESCRIPTION
Fixes Android turn by turn events not working while the app is in the background.

Fixes: https://github.com/googlemaps/react-native-navigation-sdk/issues/407

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/