### PR TITLE
fix: remove NavView fragment via the FragmentManager it is attached to

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -304,18 +304,24 @@ public class NavViewManager extends SimpleViewManager<FrameLayout>
       controllerSink.clear();
     }
 
-    FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
-    if (activity == null) return;
-
     WeakReference<IMapViewFragment> weakReference = fragmentMap.remove(viewId);
     if (weakReference != null) {
       IMapViewFragment fragment = weakReference.get();
       if (fragment != null && fragment.isAdded()) {
-        activity
-            .getSupportFragmentManager()
-            .beginTransaction()
-            .remove((Fragment) fragment)
-            .commitNowAllowingStateLoss();
+        // Remove via the FragmentManager the fragment is actually attached to.
+        // reactContext.getCurrentActivity() can be a different Activity than the one hosting the
+        // fragment (e.g. after Activity recreation), in which case removing through its
+        // FragmentManager throws "Cannot remove Fragment attached to a different FragmentManager".
+        try {
+          ((Fragment) fragment)
+              .getParentFragmentManager()
+              .beginTransaction()
+              .remove((Fragment) fragment)
+              .commitNowAllowingStateLoss();
+        } catch (IllegalStateException e) {
+          // FragmentManager already destroyed mid-teardown; the fragment is torn down with its
+          // host Activity anyway.
+        }
       }
     }
   }

--- a/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavViewManager.java
@@ -308,10 +308,6 @@ public class NavViewManager extends SimpleViewManager<FrameLayout>
     if (weakReference != null) {
       IMapViewFragment fragment = weakReference.get();
       if (fragment != null && fragment.isAdded()) {
-        // Remove via the FragmentManager the fragment is actually attached to.
-        // reactContext.getCurrentActivity() can be a different Activity than the one hosting the
-        // fragment (e.g. after Activity recreation), in which case removing through its
-        // FragmentManager throws "Cannot remove Fragment attached to a different FragmentManager".
         try {
           ((Fragment) fragment)
               .getParentFragmentManager()


### PR DESCRIPTION
Fixes #624

## Problem

`NavViewManager.onDropViewInstance` removes the map/navigation fragment through `reactContext.getCurrentActivity().getSupportFragmentManager()`. The fragment was attached to whichever Activity was current when the fragment transaction was committed. If `getCurrentActivity()` points at a different Activity at drop time — e.g. after Activity recreation while the original host is still alive — that FragmentManager never hosted the fragment, and androidx throws a fatal:

```
java.lang.IllegalStateException: Cannot remove Fragment attached to a different FragmentManager.
    at androidx.fragment.app.BackStackRecord.remove(BackStackRecord.java:204)
    at com.google.android.react.navsdk.NavViewManager.onDropViewInstance(NavViewManager.java:317)
    at com.facebook.react.fabric.mounting.SurfaceMountingManager.onViewStateDeleted(SurfaceMountingManager.java:1163)
```

`BackStackRecord.remove` throws exactly when `fragment.mFragmentManager != null && fragment.mFragmentManager != mManager`, i.e. when the transaction's FragmentManager is not the one the fragment is attached to.

## Fix

Open the remove transaction on the fragment's own `getParentFragmentManager()`, which is by definition the FragmentManager the fragment is attached to, so the mismatch can no longer occur. `isAdded()` is checked first, so `getParentFragmentManager()` cannot throw for a detached fragment; a remaining `IllegalStateException` (FragmentManager already destroyed mid-teardown) is caught, since in that case the fragment is torn down with its host Activity anyway.

This also removes the early return when `getCurrentActivity()` is null — the current Activity is no longer needed for removal, and returning early leaked the `fragmentMap` entry.

When the current Activity *is* the fragment's host (the common case), `getParentFragmentManager()` and `activity.getSupportFragmentManager()` are the same instance, so behavior is unchanged.

## Testing

- We hit this crash in production (Crashlytics, full trace in #624) in `com.apolloscooters` and have been shipping this exact change via patch-package on top of 0.16.3; the crash signature is eliminated by construction.
- `:googlemaps_react-native-navigation-sdk:compileDebugJavaWithJavac` passes with the change applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
