### PR TITLE
fix!: correct pixels for android auto padding

### DIFF
--- a/android/src/main/java/com/google/android/react/navsdk/AndroidAutoBaseScreen.java
+++ b/android/src/main/java/com/google/android/react/navsdk/AndroidAutoBaseScreen.java
@@ -20,6 +20,7 @@ import android.app.Presentation;
 import android.graphics.Point;
 import android.hardware.display.DisplayManager;
 import android.hardware.display.VirtualDisplay;
+import android.util.DisplayMetrics;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.car.app.AppManager;
@@ -62,6 +63,7 @@ public abstract class AndroidAutoBaseScreen extends Screen
   protected GoogleMap mGoogleMap;
   protected boolean mNavigationInitialized = false;
   private MapViewController mMapViewController;
+  private float mDisplayDensity = 1f;
 
   private boolean mAndroidAutoModuleInitialized = false;
   private boolean mNavModuleInitialized = false;
@@ -163,6 +165,11 @@ public abstract class AndroidAutoBaseScreen extends Screen
     }
   }
 
+  /** Returns the density of the Android Auto surface currently used. */
+  public float getDisplayDensity() {
+    return mDisplayDensity;
+  }
+
   private boolean isSurfaceReady(SurfaceContainer surfaceContainer) {
     return surfaceContainer.getSurface() != null
         && surfaceContainer.getDpi() != 0
@@ -175,6 +182,7 @@ public abstract class AndroidAutoBaseScreen extends Screen
     if (!isSurfaceReady(surfaceContainer)) {
       return;
     }
+    mDisplayDensity = surfaceContainer.getDpi() / (float) DisplayMetrics.DENSITY_DEFAULT;
     mVirtualDisplay =
         getCarContext()
             .getSystemService(DisplayManager.class)

--- a/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
+++ b/android/src/main/java/com/google/android/react/navsdk/NavAutoModule.java
@@ -25,7 +25,6 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.PixelUtil;
 import com.google.android.gms.maps.UiSettings;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.Circle;
@@ -620,18 +619,26 @@ public class NavAutoModule extends NativeNavAutoModuleSpec
 
   @Override
   public void setMapPadding(double top, double left, double bottom, double right) {
-    int topInt = Math.round(PixelUtil.toPixelFromDIP(top));
-    int leftInt = Math.round(PixelUtil.toPixelFromDIP(left));
-    int bottomInt = Math.round(PixelUtil.toPixelFromDIP(bottom));
-    int rightInt = Math.round(PixelUtil.toPixelFromDIP(right));
     UiThreadUtil.runOnUiThread(
         () -> {
           if (mMapViewController == null) {
             return;
           }
 
-          mMapViewController.setPadding(topInt, leftInt, bottomInt, rightInt);
+          float density = getAutoDisplayDensity();
+          mMapViewController.setPadding(
+              Math.round((float) (top * density)),
+              Math.round((float) (left * density)),
+              Math.round((float) (bottom * density)),
+              Math.round((float) (right * density)));
         });
+  }
+
+  private float getAutoDisplayDensity() {
+    if (mAutoScreen != null) {
+      return mAutoScreen.getDisplayDensity();
+    }
+    return reactContext.getResources().getDisplayMetrics().density;
   }
 
   @Override


### PR DESCRIPTION
BREAKING CHANGE: Fixes Android Auto map-padding scaling to use the Android Auto surface density instead of the phone display density. Uses the phone-context density only as a fallback if no Auto screen is found.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/react-native-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/