### PR TITLE
fix: tear down iOS NavView on Fabric invalidate so the map releases location

### DIFF
--- a/ios/react-native-navigation-sdk/NavView.mm
+++ b/ios/react-native-navigation-sdk/NavView.mm
@@ -40,8 +40,6 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps = [] {
 
 @property(nonatomic, strong) NavViewController *viewController;
 @property(nonatomic, assign) BOOL initialized;
-// The nativeID this view registered its controller under. Kept separately from
-// the props so teardown never depends on the props still being readable.
 @property(nonatomic, copy) NSString *registeredNativeID;
 
 @end
@@ -66,14 +64,6 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps = [] {
   [self unregisterView];
 }
 
-// Fabric calls this for unmounted views that are not pooled (shouldBeRecycled
-// is NO here), and it is the only teardown hook that actually runs for this
-// view: -dealloc never fires on its own, because NavViewModule's registry
-// holds the controller strongly and the controller holds this view strongly
-// through its _viewCallbacks ivar. That cycle outlives the unmount, leaving a
-// live GMSMapView attached to the navigation session, which keeps a
-// kCLLocationAccuracyBestForNavigation CLLocationManager subscribed for the
-// rest of the process.
 - (void)invalidate {
   [self unregisterView];
   [super invalidate];
@@ -86,8 +76,6 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps = [] {
   }
 
   if (_viewController != nil) {
-    // Releases the GMSMapView and clears the controller's strong back-reference
-    // to this view, so both sides of the cycle can be freed.
     [_viewController cleanup];
     _viewController = nil;
   }

--- a/ios/react-native-navigation-sdk/NavView.mm
+++ b/ios/react-native-navigation-sdk/NavView.mm
@@ -40,6 +40,9 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps = [] {
 
 @property(nonatomic, strong) NavViewController *viewController;
 @property(nonatomic, assign) BOOL initialized;
+// The nativeID this view registered its controller under. Kept separately from
+// the props so teardown never depends on the props still being readable.
+@property(nonatomic, copy) NSString *registeredNativeID;
 
 @end
 
@@ -63,12 +66,30 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps = [] {
   [self unregisterView];
 }
 
-- (void)unregisterView {
-  const auto &currentProps = *std::static_pointer_cast<NavViewProps const>(_props);
+// Fabric calls this for unmounted views that are not pooled (shouldBeRecycled
+// is NO here), and it is the only teardown hook that actually runs for this
+// view: -dealloc never fires on its own, because NavViewModule's registry
+// holds the controller strongly and the controller holds this view strongly
+// through its _viewCallbacks ivar. That cycle outlives the unmount, leaving a
+// live GMSMapView attached to the navigation session, which keeps a
+// kCLLocationAccuracyBestForNavigation CLLocationManager subscribed for the
+// rest of the process.
+- (void)invalidate {
+  [self unregisterView];
+  [super invalidate];
+}
 
-  if (!currentProps.nativeID.empty()) {
-    NSString *nativeIDString = [NSString stringWithUTF8String:currentProps.nativeID.c_str()];
-    [[NavViewModule viewControllersRegistry] removeObjectForKey:nativeIDString];
+- (void)unregisterView {
+  if (_registeredNativeID != nil) {
+    [[NavViewModule viewControllersRegistry] removeObjectForKey:_registeredNativeID];
+    _registeredNativeID = nil;
+  }
+
+  if (_viewController != nil) {
+    // Releases the GMSMapView and clears the controller's strong back-reference
+    // to this view, so both sides of the cycle can be freed.
+    [_viewController cleanup];
+    _viewController = nil;
   }
 }
 
@@ -140,6 +161,7 @@ static const std::shared_ptr<const NavViewProps> kDefaultNavViewProps = [] {
     // Register view controller with nativeID in the registry
     NSString *nativeIDString = [NSString stringWithUTF8String:newViewProps.nativeID.c_str()];
     [NavViewModule viewControllersRegistry][nativeIDString] = _viewController;
+    self.registeredNativeID = nativeIDString;
 
     // If navigation session is already initialized, trigger attachment check
     NavModule *navModule = [NavModule sharedInstance];

--- a/ios/react-native-navigation-sdk/NavViewController.h
+++ b/ios/react-native-navigation-sdk/NavViewController.h
@@ -51,6 +51,9 @@ typedef void (^OnArrayResult)(NSArray *_Nullable result);
 - (void)setSpeedLimitIconEnabled:(BOOL)isEnabled;
 - (void)setZoomLevel:(NSNumber *)level;
 - (void)setNavigationViewCallbacks:(id<INavigationViewCallback>)fn;
+// Releases the GMSMapView and every delegate/callback reference this controller
+// holds. Safe to call more than once; -dealloc calls it too.
+- (void)cleanup;
 - (void)setIndoorEnabled:(BOOL)isEnabled;
 - (void)setIndoorLevelPickerEnabled:(BOOL)isEnabled;
 - (void)setTrafficEnabled:(BOOL)isEnabled;

--- a/ios/react-native-navigation-sdk/NavViewController.h
+++ b/ios/react-native-navigation-sdk/NavViewController.h
@@ -51,8 +51,6 @@ typedef void (^OnArrayResult)(NSArray *_Nullable result);
 - (void)setSpeedLimitIconEnabled:(BOOL)isEnabled;
 - (void)setZoomLevel:(NSNumber *)level;
 - (void)setNavigationViewCallbacks:(id<INavigationViewCallback>)fn;
-// Releases the GMSMapView and every delegate/callback reference this controller
-// holds. Safe to call more than once; -dealloc calls it too.
 - (void)cleanup;
 - (void)setIndoorEnabled:(BOOL)isEnabled;
 - (void)setIndoorLevelPickerEnabled:(BOOL)isEnabled;


### PR DESCRIPTION
Fixes #631

On iOS (Fabric), unmounting a `NavigationView` leaks the `NavViewController` and its `GMSMapView`: `NavViewModule`'s static registry holds the controller strongly, and the controller holds the `NavView` back strongly through its `_viewCallbacks` ivar. The only teardown path is `NavView`'s `-dealloc`, which that cycle prevents from ever running. The leaked map view stays attached to the navigation session and keeps a `kCLLocationAccuracyBestForNavigation` `CLLocationManager` subscribed for the rest of the process — the status-bar location indicator stays on with no map on screen and no guidance running, and with "Always" authorization iOS keeps feeding it in the background.

### Changes

- **`NavView.mm`**: override `-invalidate` — the hook Fabric actually calls for unmounted views that are not pooled (`shouldBeRecycled` is `NO`) — and tear down from there.
- **`NavView.mm`**: cache the `nativeID` at registration time in a `registeredNativeID` property, so `unregisterView` no longer depends on `_props` still being readable at teardown.
- **`NavView.mm`**: in `unregisterView`, also call `[_viewController cleanup]` and nil the controller. `cleanup` already exists and nils `_viewCallbacks`, which breaks both sides of the cycle so view and controller can deallocate.
- **`NavViewController.h`**: declare the existing `cleanup` method (previously only reachable from the controller's own `-dealloc`, i.e. never).

### Testing

We ship this exact change in production (Apollo Scooters app, RN 0.86, New Architecture) via `patch-package`:

- Before: mount + unmount a `NavigationView`, background the app → location indicator stays on; Xcode memory graph shows the `NavView` ↔ `NavViewController` cycle with the `GMSMapView` alive.
- After: backgrounding with the view unmounted leaves no location subscription; controller and map view deallocate on unmount.
- No regressions: the map initializes, renders, re-initializes on re-mount, and guidance keeps location alive mid-navigation as expected.
